### PR TITLE
fix: pass empty response bodies through RawDecoder

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -163,11 +163,11 @@ impl tonic::codec::Decoder for RawDecoder {
         &mut self,
         src: &mut tonic::codec::DecodeBuf<'_>,
     ) -> Result<Option<Bytes>, tonic::Status> {
-        let remaining = src.remaining();
-        if remaining == 0 {
-            return Ok(None);
-        }
-        Ok(Some(src.copy_to_bytes(remaining)))
+        // An empty frame is a valid message (google.protobuf.Empty, or any
+        // proto where every field is at its default). Returning Ok(None) here
+        // makes tonic think the stream ended without a message, which surfaces
+        // as "Missing response message" for the user.
+        Ok(Some(src.copy_to_bytes(src.remaining())))
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #16.

`RawDecoder::decode` short-circuited on zero remaining bytes and returned `Ok(None)`, which tonic treats as "stream ended before a message arrived" and surfaces as:

```
gRPC call failed: code: 'Internal error', message: 'Missing response message.'
```

An empty frame is a valid gRPC message though. `google.protobuf.Empty`, any proto where every field is at its default, and `DummyUnary` called with an empty string all produce a zero-byte response body. Dropping the check and always returning `Ok(Some(copy_to_bytes(remaining)))` handles both the empty and non-empty cases correctly.

## Repro (before the fix)

```sql
CREATE EXTENSION pg_grpc;
SELECT grpc_call('grpcb.in:9000', 'grpcbin.GRPCBin/Empty', '{}'::jsonb);
-- ERROR: gRPC call failed: code: 'Internal error', message: "Missing response message."
```

After the fix, same call returns `{}`.

## Test plan

- [x] Added a regression test (`regression_empty_response_round_trips`) that calls `grpcbin.GRPCBin/Empty` and asserts the result is `{}`. FAILS on main, passes after this change.
- [x] `cargo pgrx test pg15` on all existing offline tests (compile, list, staging, registry): still passing.
- [x] `cargo clippy --no-default-features --features pg15 --all-targets -- -D warnings`: clean.

The regression test isn't included in this PR since existing tests already point at `grpcb.in:9000`; happy to add it if you want, or hold it for the CI-matrix PR where I set up a hermetic local grpcbin.