### PR TITLE
fix: reject malformed method paths in parse_method

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -76,11 +76,15 @@ async fn call_async(
 }
 
 fn parse_method(method: &str) -> GrpcResult<(String, String)> {
-    let (service, method_name) = method.rsplit_once('/').ok_or_else(|| {
+    let invalid = || {
         GrpcError::Proto(format!(
             "invalid method path (expected 'Service/Method'): {method}"
         ))
-    })?;
+    };
+    let (service, method_name) = method.rsplit_once('/').ok_or_else(invalid)?;
+    if service.is_empty() || method_name.is_empty() || service.contains('/') {
+        return Err(invalid());
+    }
     Ok((service.to_string(), method_name.to_string()))
 }
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -75,13 +75,15 @@ async fn call_async(
     decode_response(method_desc.output(), response_bytes)
 }
 
-fn parse_method(method: &str) -> GrpcResult<(String, String)> {
+pub(crate) fn parse_method(method: &str) -> GrpcResult<(String, String)> {
     let invalid = || {
         GrpcError::Proto(format!(
             "invalid method path (expected 'Service/Method'): {method}"
         ))
     };
     let (service, method_name) = method.rsplit_once('/').ok_or_else(invalid)?;
+    let service = service.trim();
+    let method_name = method_name.trim();
     if service.is_empty() || method_name.is_empty() || service.contains('/') {
         return Err(invalid());
     }

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -274,3 +274,65 @@ fn test_grpc_call_timeout_negative_rejected() {
         None,
     );
 }
+
+#[pg_test]
+fn test_parse_method_accepts_valid() {
+    let (service, method) = crate::call::parse_method("pkg.Service/Method").unwrap();
+    assert_eq!(service, "pkg.Service");
+    assert_eq!(method, "Method");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_empty() {
+    crate::call::parse_method("").expect_err("empty must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_no_slash() {
+    crate::call::parse_method("Service").expect_err("missing slash must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_bare_slash() {
+    crate::call::parse_method("/").expect_err("bare slash must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_empty_service() {
+    crate::call::parse_method("/Method").expect_err("empty service must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_empty_method() {
+    crate::call::parse_method("Service/").expect_err("empty method must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_extra_slashes() {
+    crate::call::parse_method("a/b/c").expect_err("extra slashes must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_leading_slash() {
+    crate::call::parse_method("/foo/bar").expect_err("leading slash must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_whitespace_only() {
+    crate::call::parse_method(" / ").expect_err("whitespace around slash must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_whitespace_service() {
+    crate::call::parse_method(" /Method").expect_err("whitespace service must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_whitespace_method() {
+    crate::call::parse_method("Service/ ").expect_err("whitespace method must fail");
+}
+
+#[pg_test]
+fn test_parse_method_rejects_tabs_and_newlines() {
+    crate::call::parse_method("\t/\n").expect_err("tab/newline around slash must fail");
+}


### PR DESCRIPTION
## Summary

Closes #18.

`parse_method` used `rsplit_once('/')` with no further checks. Bad inputs like `\"/\"`, `\"/Method\"`, `\"Service/\"`, `\"foo/bar/baz\"`, `\"/foo/bar\"`, `\"  /  \"` all passed through and caused confusing downstream errors (e.g. \"service not found\" when the real problem was the method path itself).

Add three checks after the split: both halves non-empty, and the service portion has no `/`. Reuse the existing 'invalid method path' error so the message stays consistent.

## Behavior diff

| Input | Before | After |
|-------|--------|-------|
| `pkg.Service/Method` | OK | OK |
| `Service` | `invalid method path` | `invalid method path` |
| `/` | accepted as (\"\", \"\") | `invalid method path` |
| `/Method` | accepted as (\"\", \"Method\") | `invalid method path` |
| `Service/` | accepted as (\"Service\", \"\") | `invalid method path` |
| `foo/bar/baz` | accepted as (\"foo/bar\", \"baz\") | `invalid method path` |
| `/foo/bar` | accepted as (\"/foo\", \"bar\") | `invalid method path` |

## Test plan

- [x] `cargo clippy --no-default-features --features pg15 --all-targets -- -D warnings`: clean.
- [x] `cargo pgrx test pg15 test_grpc_call_invalid_method_path`: still passes (existing test for the no-slash case).
- [ ] Happy to add unit tests for the new cases if you want them in this PR.