### PR TITLE
fix: reject scheme prefix in connect()

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -65,6 +65,17 @@ fn parse_method(method: &str) -> GrpcResult<(String, String)> {
 
 // TODO: cache channels by endpoint to avoid a full TCP+HTTP/2 handshake on every SQL call.
 async fn connect(endpoint: &str) -> GrpcResult<Channel> {
+    if let Some(rest) = endpoint.strip_prefix("https://") {
+        return Err(GrpcError::Connection(format!(
+            "endpoint must be 'host:port' without a scheme (TLS is not yet supported): \
+             got 'https://{rest}'"
+        )));
+    }
+    if endpoint.starts_with("http://") {
+        return Err(GrpcError::Connection(format!(
+            "endpoint must be 'host:port' without a scheme: got '{endpoint}'"
+        )));
+    }
     Channel::from_shared(format!("http://{endpoint}"))
         .map_err(|e| GrpcError::Connection(e.to_string()))?
         .connect()


### PR DESCRIPTION
## Summary

Closes #20.

`connect` unconditionally prepended `http://` to the endpoint. Passing `http://localhost:9000` (a natural mistake) produced a URI of `http://http://localhost:9000` and failed with an opaque transport error. README forbids scheme but nothing enforced it.

Detect `http://` and `https://` at the start of the endpoint. Return a clear `Connection` error pointing at the format. For `https://`, mention that TLS isn't supported yet (see #3).

## Behavior diff

| Input | Before | After |
|-------|--------|-------|
| `localhost:9000` | connects | connects |
| `http://localhost:9000` | `Connection error: http://localhost:9000: transport error` | `Connection error: endpoint must be 'host:port' without a scheme: got 'http://localhost:9000'` |
| `https://localhost:9000` | `Connection error: https://localhost:9000: transport error` | `Connection error: endpoint must be 'host:port' without a scheme (TLS is not yet supported): got 'https://localhost:9000'` |

## Test plan

- [x] `cargo clippy --no-default-features --features pg15 --all-targets -- -D warnings`: clean.
- [ ] Happy to add unit tests if you want them in this PR.