### PR TITLE
fix: reject empty filename and source in grpc_proto_stage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,12 @@ fn grpc_call(
 
 #[pg_extern]
 fn grpc_proto_stage(filename: &str, source: &str) {
+    if filename.trim().is_empty() {
+        pgrx::error!("grpc_proto_stage: filename must not be empty");
+    }
+    if source.trim().is_empty() {
+        pgrx::error!("grpc_proto_stage: source must not be empty");
+    }
     proto_staging::stage_file(filename, source);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ mod proto;
 mod proto_registry;
 mod proto_staging;
 
+use crate::error::{GrpcError, GrpcResult};
+
 #[pg_extern]
 fn grpc_call(
     endpoint: &str,
@@ -37,13 +39,24 @@ fn grpc_call(
 
 #[pg_extern]
 fn grpc_proto_stage(filename: &str, source: &str) {
+    match validate_stage_input(filename, source) {
+        Ok(()) => proto_staging::stage_file(filename, source),
+        Err(e) => pgrx::error!("{}", e),
+    }
+}
+
+pub(crate) fn validate_stage_input(filename: &str, source: &str) -> GrpcResult<()> {
     if filename.trim().is_empty() {
-        pgrx::error!("grpc_proto_stage: filename must not be empty");
+        return Err(GrpcError::ProtoCompile(
+            "grpc_proto_stage: filename must not be empty".to_string(),
+        ));
     }
     if source.trim().is_empty() {
-        pgrx::error!("grpc_proto_stage: source must not be empty");
+        return Err(GrpcError::ProtoCompile(
+            "grpc_proto_stage: source must not be empty".to_string(),
+        ));
     }
-    proto_staging::stage_file(filename, source);
+    Ok(())
 }
 
 #[pg_extern]

--- a/src/tests/staging.rs
+++ b/src/tests/staging.rs
@@ -150,3 +150,58 @@ fn test_unstage_nonexistent_returns_false() {
         "unstaging a file that was never staged should return false"
     );
 }
+
+#[pg_test]
+fn test_validate_stage_input_accepts_normal() {
+    crate::validate_stage_input("a.proto", r#"syntax = "proto3";"#).unwrap();
+}
+
+#[pg_test]
+fn test_validate_stage_input_rejects_empty_filename() {
+    crate::validate_stage_input("", "x").expect_err("empty filename must fail");
+}
+
+#[pg_test]
+fn test_validate_stage_input_rejects_whitespace_filename() {
+    crate::validate_stage_input("   ", "x").expect_err("whitespace filename must fail");
+}
+
+#[pg_test]
+fn test_validate_stage_input_rejects_tab_newline_filename() {
+    crate::validate_stage_input("\t\n", "x").expect_err("tab/newline filename must fail");
+}
+
+#[pg_test]
+fn test_validate_stage_input_rejects_empty_source() {
+    crate::validate_stage_input("a.proto", "").expect_err("empty source must fail");
+}
+
+#[pg_test]
+fn test_validate_stage_input_rejects_whitespace_source() {
+    crate::validate_stage_input("a.proto", "   ").expect_err("whitespace source must fail");
+}
+
+#[pg_test]
+fn test_validate_stage_input_rejects_tab_newline_source() {
+    crate::validate_stage_input("a.proto", "\t\n").expect_err("tab/newline source must fail");
+}
+
+#[pg_test(error = "Proto compile error: grpc_proto_stage: filename must not be empty")]
+fn test_grpc_proto_stage_empty_filename_errors() {
+    crate::grpc_proto_stage("", r#"syntax = "proto3";"#);
+}
+
+#[pg_test(error = "Proto compile error: grpc_proto_stage: filename must not be empty")]
+fn test_grpc_proto_stage_whitespace_filename_errors() {
+    crate::grpc_proto_stage("   ", r#"syntax = "proto3";"#);
+}
+
+#[pg_test(error = "Proto compile error: grpc_proto_stage: source must not be empty")]
+fn test_grpc_proto_stage_empty_source_errors() {
+    crate::grpc_proto_stage("a.proto", "");
+}
+
+#[pg_test(error = "Proto compile error: grpc_proto_stage: source must not be empty")]
+fn test_grpc_proto_stage_whitespace_source_errors() {
+    crate::grpc_proto_stage("a.proto", "  \t\n ");
+}


### PR DESCRIPTION
## Summary

Closes #22.

`grpc_proto_stage('', ...)` and `grpc_proto_stage('   ', ...)` were silently stored in `PENDING_FILES`, only to surface later as a confusing protox parser error. Empty `source` had the same problem.

Validate at the SQL boundary with `pgrx::error!`. Caller sees a clear message on the bad call instead of chasing a downstream error.

## Test plan

- [x] `cargo clippy --no-default-features --features pg15 --all-targets -- -D warnings`: clean.
- [ ] Happy to add pg_test coverage for the new rejections if you want them in this PR.