### PR TITLE
test: run grpcbin as a CI service and thread endpoint through env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,13 @@ jobs:
     name: test
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    services:
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 9000:9000
+    env:
+      GRPCBIN_ENDPOINT: localhost:9000
     steps:
       - uses: actions/checkout@v6
 

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -3,7 +3,7 @@ fn test_grpc_call_dummyunary() {
     // Force the reflection path.
     crate::grpc_proto_unregister_all();
     let result = crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
@@ -17,7 +17,7 @@ fn test_grpc_call_dummyunary() {
 )]
 fn test_grpc_call_invalid_method_path() {
     crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "no-slash-here",
         pgrx::JsonB(serde_json::json!({})),
         None,
@@ -32,7 +32,7 @@ fn test_grpc_call_reflection_disabled_misses_registry() {
     crate::grpc_proto_unregister_all();
     crate::grpc_proto_unstage_all();
     crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
@@ -56,7 +56,7 @@ fn test_grpc_call_reflection_disabled_hits_registry() {
     crate::grpc_proto_compile();
 
     let result = crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "no-reflection"})),
         None,
@@ -82,7 +82,7 @@ fn test_grpc_call_method_not_found() {
     );
     crate::grpc_proto_compile();
     crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/NoSuchMethod",
         pgrx::JsonB(serde_json::json!({"f_string": "x"})),
         None,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,14 @@
 mod tests {
     use pgrx::prelude::*;
 
+    // Tests hit a real gRPC server that speaks the grpcbin dialect.
+    // Defaults to the public grpcb.in instance for local runs; CI points this
+    // at a containerized moul/grpcbin via GRPCBIN_ENDPOINT so the suite stays
+    // hermetic and tolerant of grpcb.in downtime.
+    fn grpcbin_endpoint() -> String {
+        std::env::var("GRPCBIN_ENDPOINT").unwrap_or_else(|_| "grpcb.in:9000".to_string())
+    }
+
     include!("call.rs");
     include!("compile.rs");
     include!("list.rs");

--- a/src/tests/registry.rs
+++ b/src/tests/registry.rs
@@ -47,7 +47,7 @@ fn test_registry_precedence_over_reflection() {
     crate::grpc_proto_compile();
 
     let result = crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"renamed_field": "winner"})),
         None,

--- a/src/tests/staging.rs
+++ b/src/tests/staging.rs
@@ -16,7 +16,7 @@ fn test_grpc_proto_stage_single_file() {
     crate::grpc_proto_compile();
 
     let result = crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "via-registry"})),
         None,
@@ -49,7 +49,7 @@ fn test_grpc_proto_stage_cross_import() {
     crate::grpc_proto_compile();
 
     let result = crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "multi-file"})),
         None,
@@ -87,7 +87,7 @@ fn test_grpc_proto_unstage_recovers_bad_file() {
     crate::grpc_proto_compile();
 
     let result = crate::grpc_call(
-        "grpcb.in:9000",
+        &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "recovered"})),
         None,


### PR DESCRIPTION
## Summary

Closes #28.

Every test hard-coded `"grpcb.in:9000"`. CLAUDE.md already flags this as fragile: grpcb.in is a public demo server with no SLA, and CI breaks whenever it hiccups (plus the suite can't run at all on a runner without outbound internet).

- Added `grpcbin_endpoint()` in `src/tests/mod.rs`, reads `GRPCBIN_ENDPOINT` with a `grpcb.in:9000` default.
- Replaced every `"grpcb.in:9000"` literal with `&grpcbin_endpoint()`.
- `test.yml` now starts `moul/grpcbin` as a services container and sets `GRPCBIN_ENDPOINT=localhost:9000`.

Local runs still work as before. CI no longer depends on the public demo server.

## Merge note

This PR and #27 (CI matrix) both touch `test.yml`. They should merge cleanly but will need a small manual resolve in whichever goes second. Happy to rebase once one lands.

## Test plan

- [x] `cargo clippy --no-default-features --features pg15 --all-targets -- -D warnings`: clean.
- [ ] Let CI run the PR to confirm the grpcbin service is reachable and tests pass.