### PR TITLE
chore: repo hygiene (MSRV, cargo-audit, status badge, bug template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,9 +55,29 @@ body:
       required: true
 
   - type: input
+    id: rust-version
+    attributes:
+      label: Rust Version
+      description: "Output of `rustc --version`."
+      placeholder: "rustc 1.82.0 (f6e511eec 2024-10-15)"
+    validations:
+      required: false
+
+  - type: input
     id: os
     attributes:
       label: OS
       placeholder: "Ubuntu 24.04 / macOS 15 / etc."
     validations:
       required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install Method
+      options:
+        - Built from source (cargo pgrx install)
+        - .deb package from a release
+        - Other
+    validations:
+      required: false

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,24 @@
+name: Audit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/audit.yml"
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-name        = "pg_grpc"
-version     = "0.2.1"
-edition     = "2021"
-authors     = ["CSenshi"]
+name         = "pg_grpc"
+version      = "0.2.1"
+edition      = "2021"
+rust-version = "1.82"
+authors      = ["CSenshi"]
 description = "PostgreSQL extension for making gRPC calls from SQL, with reflection or user-supplied .proto files."
 license     = "MIT"
 repository  = "https://github.com/CSenshi/pg_grpc"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pg_grpc
 
+[![Test](https://github.com/CSenshi/pg_grpc/actions/workflows/test.yml/badge.svg)](https://github.com/CSenshi/pg_grpc/actions/workflows/test.yml)
+
 Make gRPC calls directly from PostgreSQL SQL.
 
 


### PR DESCRIPTION
## Summary

Closes #32.

Four small, non-breaking config changes bundled together.

- **`Cargo.toml`**: `rust-version = "1.82"`. pgrx 0.17 requires at least 1.82 so pinning the floor gives a clear error for older toolchains instead of opaque compile failures.
- **`.github/workflows/audit.yml`**: `rustsec/audit-check` triggered on changes to `Cargo.lock`, `Cargo.toml`, the audit workflow itself, and on a weekly cron. Guardrail against new advisories in the dep tree.
- **`README.md`**: Test workflow status badge under the title.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`**: optional Rust version field and install-method dropdown. Both are useful triage context for pgrx build issues.

## Test plan

- [x] `cargo clippy --no-default-features --features pg15 --all-targets -- -D warnings`: clean.
- [ ] Let Actions run the audit workflow once to confirm it passes against the current `Cargo.lock`.