### PR TITLE
Feat/grpc metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,13 @@ fn grpc_call(
     endpoint: &str,
     method: &str,
     request: pgrx::JsonB,
-    timeout_ms: default!(Option<i64>, "null"),   // accepted, not yet wired up
+    metadata: default!(Option<pgrx::JsonB>, "null"),   // gRPC metadata / headers
+    timeout_ms: default!(Option<i64>, "null"),         // accepted, not yet wired up
+    use_reflection: default!(Option<bool>, "true"),
 ) -> pgrx::JsonB
 ```
+
+`metadata` is a JSON object whose values are strings or arrays of strings. Keys are silently lowercased. Keys ending in `-bin` (binary metadata) are rejected in v1.
 
 User-supplied proto management (all `#[pg_extern]` in lib.rs):
 
@@ -285,7 +289,7 @@ Tests share a single backend process, so the `PROTO_REGISTRY` and `PENDING_FILES
 
 ```sql
 -- gRPC call
-grpc_call(endpoint TEXT, method TEXT, request JSONB [, timeout_ms BIGINT]) RETURNS JSONB
+grpc_call(endpoint TEXT, method TEXT, request JSONB [, metadata JSONB] [, timeout_ms BIGINT] [, use_reflection BOOLEAN]) RETURNS JSONB
 
 -- Staging
 grpc_proto_stage(filename TEXT, source TEXT) RETURNS VOID

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ grpc_call(
     endpoint       TEXT,
     method         TEXT,
     request        JSONB,
+    metadata       JSONB   DEFAULT NULL,  -- optional gRPC metadata / headers
     timeout_ms     BIGINT  DEFAULT NULL,  -- accepted but not yet implemented
     use_reflection BOOLEAN DEFAULT TRUE
 ) RETURNS JSONB

--- a/src/call.rs
+++ b/src/call.rs
@@ -4,6 +4,7 @@ use prost_reflect::{
     DescriptorPool, DynamicMessage, MessageDescriptor, MethodDescriptor, SerializeOptions,
 };
 use serde::de::DeserializeSeed as _;
+use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
 use tonic::transport::Channel;
 
 use crate::error::{GrpcError, GrpcResult};
@@ -14,13 +15,20 @@ pub fn make_grpc_call(
     method: &str,
     request_json: serde_json::Value,
     use_reflection: bool,
+    metadata: Option<serde_json::Value>,
 ) -> GrpcResult<serde_json::Value> {
     // pgrx backends are single-threaded; a multi-thread runtime would unsafely cross the Postgres boundary.
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| GrpcError::Connection(e.to_string()))?;
-    rt.block_on(call_async(endpoint, method, request_json, use_reflection))
+    rt.block_on(call_async(
+        endpoint,
+        method,
+        request_json,
+        use_reflection,
+        metadata,
+    ))
 }
 
 async fn call_async(
@@ -28,6 +36,7 @@ async fn call_async(
     method: &str,
     request_json: serde_json::Value,
     use_reflection: bool,
+    metadata: Option<serde_json::Value>,
 ) -> GrpcResult<serde_json::Value> {
     let (service_name, method_name) = parse_method(method)?;
     let channel = connect(endpoint).await?;
@@ -50,7 +59,14 @@ async fn call_async(
     };
     let method_desc = resolve_method(&pool, &service_name, &method_name)?;
     let request_bytes = encode_request(method_desc.input(), request_json)?;
-    let response_bytes = unary_call(channel, &service_name, &method_name, request_bytes).await?;
+    let response_bytes = unary_call(
+        channel,
+        &service_name,
+        &method_name,
+        request_bytes,
+        metadata,
+    )
+    .await?;
     decode_response(method_desc.output(), response_bytes)
 }
 
@@ -102,6 +118,7 @@ async fn unary_call(
     service_name: &str,
     method_name: &str,
     body: Bytes,
+    metadata: Option<serde_json::Value>,
 ) -> GrpcResult<Bytes> {
     let path = format!("/{service_name}/{method_name}")
         .parse::<http::uri::PathAndQuery>()
@@ -112,10 +129,48 @@ async fn unary_call(
         .await
         .map_err(|e| GrpcError::Connection(e.to_string()))?;
 
-    grpc.unary(tonic::Request::new(body), path, RawBytesCodec)
+    let mut request = tonic::Request::new(body);
+    apply_metadata(&mut request, metadata)?;
+
+    grpc.unary(request, path, RawBytesCodec)
         .await
         .map(|r| r.into_inner())
         .map_err(|s| GrpcError::Call(s.to_string()))
+}
+
+pub(crate) fn apply_metadata(
+    request: &mut tonic::Request<Bytes>,
+    metadata: Option<serde_json::Value>,
+) -> GrpcResult<()> {
+    let obj = match metadata {
+        None | Some(serde_json::Value::Null) => return Ok(()),
+        Some(serde_json::Value::Object(m)) => m,
+        Some(_) => return Err(GrpcError::Call("metadata must be a JSON object".into())),
+    };
+
+    let md = request.metadata_mut();
+    for (key, val) in obj {
+        let meta_key = AsciiMetadataKey::from_bytes(key.to_ascii_lowercase().as_bytes())
+            .map_err(|e| GrpcError::Call(format!("metadata key '{key}': {e}")))?;
+
+        // 2 shapes at this level: Array => multi-value (one repeated header per item),
+        // anything else => single value (wrapped so both shapes share the loop below).
+        let items = match val {
+            serde_json::Value::Array(items) => items,
+            other => vec![other],
+        };
+        for item in items {
+            let s = match item {
+                serde_json::Value::Null => continue,
+                serde_json::Value::String(s) => s,
+                other => other.to_string(),
+            };
+            let v = AsciiMetadataValue::try_from(s.as_str())
+                .map_err(|e| GrpcError::Call(format!("metadata '{key}': {e}")))?;
+            md.append(meta_key.clone(), v);
+        }
+    }
+    Ok(())
 }
 
 fn decode_response(desc: MessageDescriptor, bytes: Bytes) -> GrpcResult<serde_json::Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,15 @@ fn grpc_call(
     request: pgrx::JsonB,
     _timeout_ms: default!(Option<i64>, "null"),
     use_reflection: default!(Option<bool>, "true"),
+    metadata: default!(Option<pgrx::JsonB>, "null"),
 ) -> pgrx::JsonB {
-    match call::make_grpc_call(endpoint, method, request.0, use_reflection.unwrap_or(true)) {
+    match call::make_grpc_call(
+        endpoint,
+        method,
+        request.0,
+        use_reflection.unwrap_or(true),
+        metadata.map(|j| j.0),
+    ) {
         Ok(value) => pgrx::JsonB(value),
         Err(e) => pgrx::error!("{}", e),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@ fn grpc_call(
     endpoint: &str,
     method: &str,
     request: pgrx::JsonB,
+    metadata: default!(Option<pgrx::JsonB>, "null"),
     _timeout_ms: default!(Option<i64>, "null"),
     use_reflection: default!(Option<bool>, "true"),
-    metadata: default!(Option<pgrx::JsonB>, "null"),
 ) -> pgrx::JsonB {
     match call::make_grpc_call(
         endpoint,

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -8,6 +8,7 @@ fn test_grpc_call_dummyunary() {
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
         None,
+        None,
     );
     assert_eq!(result.0["f_string"], "hello");
 }
@@ -20,6 +21,7 @@ fn test_grpc_call_invalid_method_path() {
         &grpcbin_endpoint(),
         "no-slash-here",
         pgrx::JsonB(serde_json::json!({})),
+        None,
         None,
         None,
     );
@@ -37,6 +39,7 @@ fn test_grpc_call_reflection_disabled_misses_registry() {
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
         Some(false),
+        None,
     );
 }
 
@@ -61,6 +64,7 @@ fn test_grpc_call_reflection_disabled_hits_registry() {
         pgrx::JsonB(serde_json::json!({"f_string": "no-reflection"})),
         None,
         Some(false),
+        None,
     );
     assert_eq!(result.0["f_string"], "no-reflection");
 
@@ -87,5 +91,148 @@ fn test_grpc_call_method_not_found() {
         pgrx::JsonB(serde_json::json!({"f_string": "x"})),
         None,
         None,
+        None,
     );
+}
+
+#[pg_test]
+fn test_grpc_call_with_metadata_smoke() {
+    crate::grpc_proto_unregister_all();
+    let result = crate::grpc_call(
+        &grpcbin_endpoint(),
+        "grpcbin.GRPCBin/DummyUnary",
+        pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
+        None,
+        None,
+        Some(pgrx::JsonB(serde_json::json!({
+            "authorization": "Bearer tok",
+            "x-trace-id": "abc"
+        }))),
+    );
+    assert_eq!(result.0["f_string"], "hello");
+}
+
+#[pg_test]
+fn test_metadata_none() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, None).unwrap();
+    assert_eq!(req.metadata().len(), 0);
+}
+
+#[pg_test]
+fn test_metadata_null_is_noop() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, Some(serde_json::Value::Null)).unwrap();
+    assert_eq!(req.metadata().len(), 0);
+}
+
+#[pg_test]
+fn test_metadata_ascii_single() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(
+        &mut req,
+        Some(serde_json::json!({"authorization": "Bearer tok"})),
+    )
+    .unwrap();
+    assert_eq!(
+        req.metadata().get("authorization").unwrap().to_str().ok(),
+        Some("Bearer tok"),
+    );
+}
+
+#[pg_test]
+fn test_metadata_uppercase_key_lowercased() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, Some(serde_json::json!({"Authorization": "x"}))).unwrap();
+    assert!(req.metadata().get("authorization").is_some());
+    assert!(req.metadata().get("Authorization").is_some());
+}
+
+#[pg_test]
+fn test_metadata_multi_value() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, Some(serde_json::json!({"x-multi": ["a", "b"]}))).unwrap();
+    let values: Vec<_> = req
+        .metadata()
+        .get_all("x-multi")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_string())
+        .collect();
+    assert_eq!(values, vec!["a".to_string(), "b".to_string()]);
+}
+
+#[pg_test]
+fn test_metadata_bin_key_rejected() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, Some(serde_json::json!({"foo-bin": "x"})))
+        .expect_err("bin key must error");
+}
+
+#[pg_test]
+fn test_metadata_invalid_key_chars() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, Some(serde_json::json!({"bad key": "x"})))
+        .expect_err("space in key must error");
+}
+
+#[pg_test]
+fn test_metadata_scalar_coercion() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(
+        &mut req,
+        Some(serde_json::json!({"x-num": 42, "x-bool": true})),
+    )
+    .unwrap();
+    assert_eq!(req.metadata().get("x-num").unwrap().to_str().ok(), Some("42"));
+    assert_eq!(req.metadata().get("x-bool").unwrap().to_str().ok(), Some("true"));
+}
+
+#[pg_test]
+fn test_metadata_object_serialized_as_json() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(
+        &mut req,
+        Some(serde_json::json!({"x-user": {"id": 1, "name": "alice"}})),
+    )
+    .unwrap();
+    assert_eq!(
+        req.metadata().get("x-user").unwrap().to_str().ok(),
+        Some(r#"{"id":1,"name":"alice"}"#),
+    );
+}
+
+#[pg_test]
+fn test_metadata_null_value_skipped() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(
+        &mut req,
+        Some(serde_json::json!({"x-skip": null, "x-keep": "v"})),
+    )
+    .unwrap();
+    assert!(req.metadata().get("x-skip").is_none());
+    assert_eq!(req.metadata().get("x-keep").unwrap().to_str().ok(), Some("v"));
+}
+
+#[pg_test]
+fn test_metadata_mixed_array_serialized() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(
+        &mut req,
+        Some(serde_json::json!({"x-mix": ["a", 42, {"k": "v"}]})),
+    )
+    .unwrap();
+    let values: Vec<_> = req
+        .metadata()
+        .get_all("x-mix")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_string())
+        .collect();
+    assert_eq!(values, vec!["a", "42", r#"{"k":"v"}"#]);
+}
+
+#[pg_test]
+fn test_metadata_non_object() {
+    let mut req = tonic::Request::new(bytes::Bytes::new());
+    crate::call::apply_metadata(&mut req, Some(serde_json::json!([1, 2, 3])))
+        .expect_err("array at top must error");
 }

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -38,8 +38,8 @@ fn test_grpc_call_reflection_disabled_misses_registry() {
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
-        Some(false),
         None,
+        Some(false),
     );
 }
 
@@ -63,8 +63,8 @@ fn test_grpc_call_reflection_disabled_hits_registry() {
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "no-reflection"})),
         None,
-        Some(false),
         None,
+        Some(false),
     );
     assert_eq!(result.0["f_string"], "no-reflection");
 
@@ -102,12 +102,12 @@ fn test_grpc_call_with_metadata_smoke() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
-        None,
-        None,
         Some(pgrx::JsonB(serde_json::json!({
             "authorization": "Bearer tok",
             "x-trace-id": "abc"
         }))),
+        None,
+        None,
     );
     assert_eq!(result.0["f_string"], "hello");
 }

--- a/src/tests/registry.rs
+++ b/src/tests/registry.rs
@@ -52,6 +52,7 @@ fn test_registry_precedence_over_reflection() {
         pgrx::JsonB(serde_json::json!({"renamed_field": "winner"})),
         None,
         None,
+        None,
     );
     assert_eq!(result.0["renamed_field"], "winner");
     assert!(

--- a/src/tests/staging.rs
+++ b/src/tests/staging.rs
@@ -21,6 +21,7 @@ fn test_grpc_proto_stage_single_file() {
         pgrx::JsonB(serde_json::json!({"f_string": "via-registry"})),
         None,
         None,
+        None,
     );
     assert_eq!(result.0["f_string"], "via-registry");
 }
@@ -52,6 +53,7 @@ fn test_grpc_proto_stage_cross_import() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "multi-file"})),
+        None,
         None,
         None,
     );
@@ -90,6 +92,7 @@ fn test_grpc_proto_unstage_recovers_bad_file() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "recovered"})),
+        None,
         None,
         None,
     );


### PR DESCRIPTION
## Summary

Implement calling grpc requests with metadata. Closes #6 

## Checklist

- [X] `cargo pgrx test all` passes
- [X] `cargo clippy` clean
- [X] `cargo fmt` applied
- [X] No breaking changes to SQL API (or documented in summary)
