### PR TITLE
feat: implement timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ fn grpc_call(
     method: &str,
     request: pgrx::JsonB,
     metadata: default!(Option<pgrx::JsonB>, "null"),   // gRPC metadata / headers
-    timeout_ms: default!(Option<i64>, "null"),         // accepted, not yet wired up
+    timeout_ms: default!(Option<i64>, "null"),         // defaults to 30_000ms; must be > 0
     use_reflection: default!(Option<bool>, "true"),
 ) -> pgrx::JsonB
 ```
@@ -282,7 +282,6 @@ Tests share a single backend process, so the `PROTO_REGISTRY` and `PENDING_FILES
 - **HTTP only** — TLS/mTLS not supported (no `tonic::transport::ClientTlsConfig` wiring yet)
 - **Unary RPCs only** — streaming methods not supported
 - **No connection caching** — fresh TCP + HTTP/2 handshake on every `grpc_call`
-- **`timeout_ms` is accepted but ignored**
 - **Multi-file proto imports must use filenames that match staging keys** — `import "common.proto";` only resolves if someone ran `grpc_proto_stage('common.proto', ...)`
 
 ## API Summary

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ grpc_call(
     method         TEXT,
     request        JSONB,
     metadata       JSONB   DEFAULT NULL,  -- optional gRPC metadata / headers
-    timeout_ms     BIGINT  DEFAULT NULL,  -- accepted but not yet implemented
+    timeout_ms     BIGINT  DEFAULT NULL,  -- defaults to 30_000ms; must be > 0
     use_reflection BOOLEAN DEFAULT TRUE
 ) RETURNS JSONB
 ```
@@ -105,6 +105,7 @@ All errors raise a PostgreSQL `ERROR` and abort the current statement:
 | `Proto error: …`         | Reflection failed, symbol not found, or JSON ↔ protobuf encode/decode error |
 | `Proto compile error: …` | `grpc_proto_compile` failed to parse/resolve the staged files               |
 | `gRPC call failed: …`    | Server returned a non-OK gRPC status                                        |
+| `Request timeout: …ms`   | The call (connect + reflection + unary) did not finish within `timeout_ms`  |
 
 ## Limitations
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -16,19 +16,24 @@ pub fn make_grpc_call(
     request_json: serde_json::Value,
     use_reflection: bool,
     metadata: Option<serde_json::Value>,
+    timeout_ms: u64,
 ) -> GrpcResult<serde_json::Value> {
     // pgrx backends are single-threaded; a multi-thread runtime would unsafely cross the Postgres boundary.
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| GrpcError::Connection(e.to_string()))?;
-    rt.block_on(call_async(
-        endpoint,
-        method,
-        request_json,
-        use_reflection,
-        metadata,
-    ))
+    rt.block_on(async {
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            call_async(endpoint, method, request_json, use_reflection, metadata),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(GrpcError::Timeout(timeout_ms)),
+        }
+    })
 }
 
 async fn call_async(

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum GrpcError {
     ProtoCompile(String),
     #[error("gRPC call failed: {0}")]
     Call(String),
+    #[error("Request timeout: {0}ms")]
+    Timeout(u64),
 }
 
 pub type GrpcResult<T> = Result<T, GrpcError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,21 @@ fn grpc_call(
     method: &str,
     request: pgrx::JsonB,
     metadata: default!(Option<pgrx::JsonB>, "null"),
-    _timeout_ms: default!(Option<i64>, "null"),
+    timeout_ms: default!(Option<i64>, "null"),
     use_reflection: default!(Option<bool>, "true"),
 ) -> pgrx::JsonB {
+    let timeout_ms = match timeout_ms {
+        Some(v) if v <= 0 => pgrx::error!("timeout_ms must be positive (got {})", v),
+        Some(v) => v as u64,
+        None => 30_000,
+    };
     match call::make_grpc_call(
         endpoint,
         method,
         request.0,
         use_reflection.unwrap_or(true),
         metadata.map(|j| j.0),
+        timeout_ms,
     ) {
         Ok(value) => pgrx::JsonB(value),
         Err(e) => pgrx::error!("{}", e),

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -236,3 +236,41 @@ fn test_metadata_non_object() {
     crate::call::apply_metadata(&mut req, Some(serde_json::json!([1, 2, 3])))
         .expect_err("array at top must error");
 }
+
+#[pg_test(error = "Request timeout: 200ms")]
+fn test_grpc_call_timeout_fires() {
+    // 10.255.255.1 is in TEST-NET-1-adjacent unroutable space; the connect
+    // will hang long past our 200ms budget, forcing the timeout path.
+    crate::grpc_call(
+        "10.255.255.1:50051",
+        "x.Y/Z",
+        pgrx::JsonB(serde_json::json!({})),
+        None,
+        Some(200),
+        None,
+    );
+}
+
+#[pg_test(error = "timeout_ms must be positive (got 0)")]
+fn test_grpc_call_timeout_zero_rejected() {
+    crate::grpc_call(
+        &grpcbin_endpoint(),
+        "grpcbin.GRPCBin/DummyUnary",
+        pgrx::JsonB(serde_json::json!({"f_string": "hi"})),
+        None,
+        Some(0),
+        None,
+    );
+}
+
+#[pg_test(error = "timeout_ms must be positive (got -5)")]
+fn test_grpc_call_timeout_negative_rejected() {
+    crate::grpc_call(
+        &grpcbin_endpoint(),
+        "grpcbin.GRPCBin/DummyUnary",
+        pgrx::JsonB(serde_json::json!({"f_string": "hi"})),
+        None,
+        Some(-5),
+        None,
+    );
+}


### PR DESCRIPTION
## Summary

Implement `timeout_ms` functionality, throws `GrpcError::Timeout` error

## Checklist

- [X] `cargo pgrx test all` passes
- [X] `cargo clippy` clean
- [X] `cargo fmt` applied
- [X] No breaking changes to SQL API (or documented in summary)
