### PR TITLE
feat: validate endpoint before connect

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeSeed as _;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
 use tonic::transport::Channel;
 
+use crate::endpoint::validate_endpoint;
 use crate::error::{GrpcError, GrpcResult};
 use crate::proto;
 
@@ -92,6 +93,7 @@ pub(crate) fn parse_method(method: &str) -> GrpcResult<(String, String)> {
 
 // TODO: cache channels by endpoint to avoid a full TCP+HTTP/2 handshake on every SQL call.
 async fn connect(endpoint: &str) -> GrpcResult<Channel> {
+    let endpoint = validate_endpoint(endpoint)?;
     Channel::from_shared(format!("http://{endpoint}"))
         .map_err(|e| GrpcError::Connection(e.to_string()))?
         .connect()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,0 +1,11 @@
+use crate::error::{GrpcError, GrpcResult};
+
+pub fn validate_endpoint(endpoint: &str) -> GrpcResult<String> {
+    let trimmed = endpoint.trim();
+    if trimmed.is_empty() {
+        return Err(GrpcError::Connection(
+            "endpoint must not be empty".to_string(),
+        ));
+    }
+    Ok(trimmed.to_owned())
+}

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -7,5 +7,15 @@ pub fn validate_endpoint(endpoint: &str) -> GrpcResult<String> {
             "endpoint must not be empty".to_string(),
         ));
     }
+    if trimmed.contains("://") {
+        return Err(GrpcError::Connection(format!(
+            "endpoint must not contain scheme (found '://'): {trimmed}"
+        )));
+    }
+    if trimmed.contains('/') {
+        return Err(GrpcError::Connection(format!(
+            "endpoint must not contain path (found '/'): {trimmed}"
+        )));
+    }
     Ok(trimmed.to_owned())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use pgrx::prelude::*;
 ::pgrx::pg_module_magic!(name, version);
 
 mod call;
+mod endpoint;
 mod error;
 mod proto;
 mod proto_registry;

--- a/src/tests/endpoint.rs
+++ b/src/tests/endpoint.rs
@@ -51,3 +51,39 @@ fn test_validate_endpoint_rejects_path() {
 fn test_validate_endpoint_rejects_trailing_slash() {
     crate::endpoint::validate_endpoint("localhost:50051/").expect_err("trailing slash must fail");
 }
+
+#[pg_test]
+fn test_validate_endpoint_accepts_ipv6_bracketed() {
+    let got = crate::endpoint::validate_endpoint("[::1]:50051").unwrap();
+    assert_eq!(got, "[::1]:50051");
+}
+
+#[pg_test]
+fn test_validate_endpoint_accepts_hostname() {
+    let got = crate::endpoint::validate_endpoint("api.example.com:443").unwrap();
+    assert_eq!(got, "api.example.com:443");
+}
+
+#[pg_test(error = "Connection error: endpoint must not contain scheme (found '://'): http://localhost:50051")]
+fn test_grpc_call_rejects_http_prefixed_endpoint() {
+    crate::grpc_call(
+        "http://localhost:50051",
+        "pkg.Service/Method",
+        pgrx::JsonB(serde_json::json!({})),
+        None,
+        None,
+        None,
+    );
+}
+
+#[pg_test(error = "Connection error: endpoint must not be empty")]
+fn test_grpc_call_rejects_empty_endpoint() {
+    crate::grpc_call(
+        "",
+        "pkg.Service/Method",
+        pgrx::JsonB(serde_json::json!({})),
+        None,
+        None,
+        None,
+    );
+}

--- a/src/tests/endpoint.rs
+++ b/src/tests/endpoint.rs
@@ -1,0 +1,25 @@
+#[pg_test]
+fn test_validate_endpoint_accepts_host_port() {
+    let got = crate::endpoint::validate_endpoint("localhost:50051").unwrap();
+    assert_eq!(got, "localhost:50051");
+}
+
+#[pg_test]
+fn test_validate_endpoint_rejects_empty() {
+    let err = crate::endpoint::validate_endpoint("").expect_err("empty must fail");
+    assert!(
+        matches!(err, crate::error::GrpcError::Connection(_)),
+        "expected Connection variant, got {err:?}"
+    );
+}
+
+#[pg_test]
+fn test_validate_endpoint_rejects_whitespace_only() {
+    crate::endpoint::validate_endpoint("   \t\n").expect_err("whitespace-only must fail");
+}
+
+#[pg_test]
+fn test_validate_endpoint_trims_surrounding_whitespace() {
+    let got = crate::endpoint::validate_endpoint("  localhost:50051\n").unwrap();
+    assert_eq!(got, "localhost:50051");
+}

--- a/src/tests/endpoint.rs
+++ b/src/tests/endpoint.rs
@@ -23,3 +23,31 @@ fn test_validate_endpoint_trims_surrounding_whitespace() {
     let got = crate::endpoint::validate_endpoint("  localhost:50051\n").unwrap();
     assert_eq!(got, "localhost:50051");
 }
+
+#[pg_test]
+fn test_validate_endpoint_rejects_http_scheme() {
+    let err =
+        crate::endpoint::validate_endpoint("http://localhost:50051").expect_err("scheme must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("scheme"), "unexpected error: {msg}");
+    assert!(msg.contains("://"), "unexpected error: {msg}");
+}
+
+#[pg_test]
+fn test_validate_endpoint_rejects_grpcs_scheme() {
+    crate::endpoint::validate_endpoint("grpcs://host:443").expect_err("scheme must fail");
+}
+
+#[pg_test]
+fn test_validate_endpoint_rejects_path() {
+    let err = crate::endpoint::validate_endpoint("localhost:50051/foo")
+        .expect_err("path must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("path"), "unexpected error: {msg}");
+    assert!(msg.contains('/'), "unexpected error: {msg}");
+}
+
+#[pg_test]
+fn test_validate_endpoint_rejects_trailing_slash() {
+    crate::endpoint::validate_endpoint("localhost:50051/").expect_err("trailing slash must fail");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod tests {
 
     include!("call.rs");
     include!("compile.rs");
+    include!("endpoint.rs");
     include!("list.rs");
     include!("registry.rs");
     include!("staging.rs");


### PR DESCRIPTION
## Summary
- Add `validate_endpoint` module: trims whitespace; rejects empty, `://`, and `/` — reuses existing `GrpcError::Connection`.
- Wire validator into `call::connect` before `Channel::from_shared`, so `http://host:port` and similar footguns fail fast with a clear message instead of tonic's confusing `http://http://...` error.
- 12 new `#[pg_test]`s covering every reject branch plus representative accepts (`host:port`, `[::1]:50051`, `api.example.com:443`) and two integration tests via `grpc_call`.

Closes #39.

## Test plan
- [x] `cargo pgrx test pg18` — 77 passed
- [x] `cargo clippy --all-targets --no-default-features --features "pg18 pg_test"` — clean
- [x] `cargo fmt --check` — clean