### PR TITLE
feat: cache tonic Channels across grpc_call invocations

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeSeed as _;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
 use tonic::transport::Channel;
 
-use crate::endpoint::validate_endpoint;
+use crate::channel_cache;
 use crate::error::{GrpcError, GrpcResult};
 use crate::proto;
 
@@ -45,7 +45,7 @@ async fn call_async(
     metadata: Option<serde_json::Value>,
 ) -> GrpcResult<serde_json::Value> {
     let (service_name, method_name) = parse_method(method)?;
-    let channel = connect(endpoint).await?;
+    let channel = channel_cache::get_or_connect(endpoint).await?;
     let pool = match crate::proto_registry::get_proto(&service_name) {
         Some(pool) => pool,
         None if use_reflection => {
@@ -89,16 +89,6 @@ pub(crate) fn parse_method(method: &str) -> GrpcResult<(String, String)> {
         return Err(invalid());
     }
     Ok((service.to_string(), method_name.to_string()))
-}
-
-// TODO: cache channels by endpoint to avoid a full TCP+HTTP/2 handshake on every SQL call.
-async fn connect(endpoint: &str) -> GrpcResult<Channel> {
-    let endpoint = validate_endpoint(endpoint)?;
-    Channel::from_shared(format!("http://{endpoint}"))
-        .map_err(|e| GrpcError::Connection(e.to_string()))?
-        .connect()
-        .await
-        .map_err(|e| GrpcError::Connection(format!("{endpoint}: {e}")))
 }
 
 fn resolve_method(

--- a/src/channel_cache.rs
+++ b/src/channel_cache.rs
@@ -1,0 +1,40 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use tonic::transport::Channel;
+
+use crate::endpoint::validate_endpoint;
+use crate::error::{GrpcError, GrpcResult};
+
+// Process-global Channel cache, keyed by the validated endpoint string.
+// tonic::transport::Channel is Arc-backed, so clones share the same underlying
+// connection pool and HTTP/2 session, including its auto-reconnect behavior.
+static CHANNELS: LazyLock<RwLock<HashMap<String, Channel>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+pub async fn get_or_connect(endpoint: &str) -> GrpcResult<Channel> {
+    let key = validate_endpoint(endpoint)?;
+    if let Some(channel) = CHANNELS.read().get(&key).cloned() {
+        return Ok(channel);
+    }
+    let channel = Channel::from_shared(format!("http://{key}"))
+        .map_err(|e| GrpcError::Connection(e.to_string()))?
+        .connect()
+        .await
+        .map_err(|e| GrpcError::Connection(format!("{key}: {e}")))?;
+    Ok(CHANNELS
+        .write()
+        .entry(key)
+        .or_insert(channel)
+        .clone())
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+pub fn len() -> usize {
+    CHANNELS.read().len()
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+pub fn clear() {
+    CHANNELS.write().clear();
+}

--- a/src/channel_cache.rs
+++ b/src/channel_cache.rs
@@ -22,11 +22,7 @@ pub async fn get_or_connect(endpoint: &str) -> GrpcResult<Channel> {
         .connect()
         .await
         .map_err(|e| GrpcError::Connection(format!("{key}: {e}")))?;
-    Ok(CHANNELS
-        .write()
-        .entry(key)
-        .or_insert(channel)
-        .clone())
+    Ok(CHANNELS.write().entry(key).or_insert(channel).clone())
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use pgrx::prelude::*;
 ::pgrx::pg_module_magic!(name, version);
 
 mod call;
+mod channel_cache;
 mod endpoint;
 mod error;
 mod proto;

--- a/src/tests/channel_cache.rs
+++ b/src/tests/channel_cache.rs
@@ -14,3 +14,27 @@ fn test_channel_cache_first_lookup_stores_channel() {
     assert_eq!(crate::channel_cache::len(), 1);
     crate::channel_cache::clear();
 }
+
+#[pg_test]
+fn test_channel_cache_second_lookup_is_cache_hit() {
+    crate::channel_cache::clear();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let endpoint = grpcbin_endpoint();
+    rt.block_on(async {
+        crate::channel_cache::get_or_connect(&endpoint)
+            .await
+            .expect("first lookup should connect");
+        crate::channel_cache::get_or_connect(&endpoint)
+            .await
+            .expect("second lookup should hit cache");
+    });
+    assert_eq!(
+        crate::channel_cache::len(),
+        1,
+        "second lookup must not create a new entry"
+    );
+    crate::channel_cache::clear();
+}

--- a/src/tests/channel_cache.rs
+++ b/src/tests/channel_cache.rs
@@ -1,0 +1,16 @@
+#[pg_test]
+fn test_channel_cache_first_lookup_stores_channel() {
+    crate::channel_cache::clear();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let endpoint = grpcbin_endpoint();
+    rt.block_on(async {
+        crate::channel_cache::get_or_connect(&endpoint)
+            .await
+            .expect("first lookup should connect");
+    });
+    assert_eq!(crate::channel_cache::len(), 1);
+    crate::channel_cache::clear();
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod tests {
     }
 
     include!("call.rs");
+    include!("channel_cache.rs");
     include!("compile.rs");
     include!("endpoint.rs");
     include!("list.rs");


### PR DESCRIPTION
## Summary
- Add process-global `channel_cache` module (HashMap behind `parking_lot::RwLock`) so repeated `grpc_call` invocations to the same endpoint reuse the cached `tonic::transport::Channel` instead of redoing the TCP + HTTP/2 handshake.
- Replace the local `connect()` helper in `src/call.rs` with a single call into the cache module.
- Two unit tests: first lookup populates the cache; second lookup same endpoint is a cache hit (single entry).

Closes #40.

## Notes
- Channel cloning is cheap (Arc-backed); tonic's auto-reconnect behavior is preserved, so a transient network blip does not require invalidation.
- No new SQL-facing functions (no `grpc_close*`). Backend reconnect remains the only escape hatch, matching the `proto_registry` idiom.
- Failed connects are not cached (the `?` returns before the insert).
- Cache key is the validated endpoint string only; TLS will fold into the key in a later slice.

## Test plan
- [x] `cargo pgrx test pg18` — 79 passed
- [x] `cargo clippy --features pg_test --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean