### PR TITLE
feat: server-auth TLS for grpc_call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,12 @@ SELECT grpc_call('localhost:50051', 'pkg.Service/Method', '{"foo": "bar"}'::json
 
 ```
 src/
-├── lib.rs              # pg_module_magic!(), all #[pg_extern] SQL functions, #[pg_test]s
+├── lib.rs              # pg_module_magic!(), _PG_init (rustls ring), all #[pg_extern] SQL functions, #[pg_test]s
 ├── error.rs            # Centralized GrpcError enum + GrpcResult<T> type alias
-├── call.rs             # gRPC call orchestration: parse_method → connect → resolve_pool → encode → unary_call → decode
+├── call.rs             # gRPC call orchestration: parse_method → channel_cache → resolve_pool → encode → unary_call → decode
+├── channel_cache.rs    # CHANNELS static: (endpoint, Option<TlsConfig>) → Channel, with auto-reconnect via tonic
+├── endpoint.rs         # validate_endpoint: reject scheme/path/empty, trim whitespace
+├── tls.rs              # TlsConfig: strict JSONB parsing → tonic::transport::ClientTlsConfig
 ├── proto.rs            # Reflection (fetch_pool) + user-supplied proto compilation (compile_proto_files)
 ├── proto_staging.rs    # PENDING_FILES static: grpc_proto_stage writes here, grpc_proto_compile drains
 └── proto_registry.rs   # PROTO_REGISTRY static: compiled DescriptorPools keyed by fully-qualified service name
@@ -51,7 +54,8 @@ pg_grpc.control         # Extension metadata (name, version, schema, superuser)
 ## Dependencies
 
 - **pgrx 0.18** — Postgres extension framework
-- **tonic 0.14 / tonic-reflection 0.14** — gRPC client, reflection
+- **tonic 0.14 / tonic-reflection 0.14** — gRPC client, reflection (features `channel`, `codegen`, `tls-ring`, `tls-native-roots`)
+- **rustls 0.23** (`ring` feature) — provider installed once at `_PG_init`
 - **prost 0.14 / prost-types 0.14 / prost-reflect 0.16** — protobuf encode/decode + dynamic schema
 - **protox 0.9** — pure-Rust `.proto` compiler (used by `compile_proto_files`)
 - **once_cell + parking_lot** — process-global staging / registry statics
@@ -113,10 +117,13 @@ fn grpc_call(
     metadata: default!(Option<pgrx::JsonB>, "null"),   // gRPC metadata / headers
     timeout_ms: default!(Option<i64>, "null"),         // defaults to 30_000ms; must be > 0
     use_reflection: default!(Option<bool>, "true"),
+    tls: default!(Option<pgrx::JsonB>, "null"),        // NULL → plaintext; object → TLS
 ) -> pgrx::JsonB
 ```
 
 `metadata` is a JSON object whose values are strings or arrays of strings. Keys are silently lowercased. Keys ending in `-bin` (binary metadata) are rejected in v1.
+
+`tls` controls transport security. `NULL` (default) keeps the current plaintext behavior; `'{}'::jsonb` turns on TLS with the OS trust store; `'{"ca_cert": "<PEM>"}'::jsonb` adds a private-CA root on top. Reflection runs over the same channel, so `use_reflection => true` with a non-null `tls` reflects over TLS. Parsing is strict: unknown keys and empty-string values raise a `Connection error`. mTLS (`client_cert`, `client_key`) and SNI override (`domain_name`) are not yet implemented.
 
 User-supplied proto management (all `#[pg_extern]` in lib.rs):
 
@@ -211,10 +218,12 @@ The `InMemoryResolver` in `proto.rs` implements `protox::file::FileResolver` —
 ## Proto Resolution Flow (full picture)
 
 ```
-grpc_call("host:port", "pkg.Service/Method", {...})
+grpc_call("host:port", "pkg.Service/Method", {...}, tls => NULL | '{...}')
     │
     ├─► parse_method → ("pkg.Service", "Method")
-    ├─► connect(endpoint)                          (new Channel every call — no caching)
+    ├─► tls::TlsConfig::parse(tls) (if non-null, strict; unknown keys rejected)
+    ├─► channel_cache::get_or_connect(endpoint, tls)
+    │       key = (endpoint, Option<TlsConfig>); http:// when tls is None, https:// otherwise
     ├─► proto_registry::get_proto("pkg.Service")
     │       ├─► hit  → use cached pool (user-staged or reflection)
     │       └─► miss → proto::fetch_pool via reflection, then insert_reflection
@@ -242,7 +251,7 @@ mod tests {
             "grpcb.in:9000",
             "grpcbin.GRPCBin/DummyUnary",
             pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
-            None,
+            None, None, None, None,
         );
         assert_eq!(result.0["f_string"], "hello");
     }
@@ -279,16 +288,15 @@ Tests share a single backend process, so the `PROTO_REGISTRY` and `PENDING_FILES
 
 ## Current Limitations
 
-- **HTTP only** — TLS/mTLS not supported (no `tonic::transport::ClientTlsConfig` wiring yet)
+- **Server-auth TLS only** — mTLS (`client_cert`, `client_key`) and SNI override (`domain_name`) not yet wired
 - **Unary RPCs only** — streaming methods not supported
-- **No connection caching** — fresh TCP + HTTP/2 handshake on every `grpc_call`
 - **Multi-file proto imports must use filenames that match staging keys** — `import "common.proto";` only resolves if someone ran `grpc_proto_stage('common.proto', ...)`
 
 ## API Summary
 
 ```sql
 -- gRPC call
-grpc_call(endpoint TEXT, method TEXT, request JSONB [, metadata JSONB] [, timeout_ms BIGINT] [, use_reflection BOOLEAN]) RETURNS JSONB
+grpc_call(endpoint TEXT, method TEXT, request JSONB [, metadata JSONB] [, timeout_ms BIGINT] [, use_reflection BOOLEAN] [, tls JSONB]) RETURNS JSONB
 
 -- Staging
 grpc_proto_stage(filename TEXT, source TEXT) RETURNS VOID

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -534,6 +550,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1042,7 +1069,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1096,6 +1123,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -1180,6 +1213,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1624,6 +1658,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,7 +1696,54 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1667,6 +1762,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1781,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1802,7 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1821,6 +1948,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -1888,7 +2021,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1967,7 +2100,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1994,6 +2139,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2076,8 +2231,10 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -2237,6 +2394,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2452,7 +2615,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2516,6 +2679,15 @@ name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
@@ -2771,6 +2943,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,15 @@ pgrx        = "=0.18.0"
 serde_json  = "1"
 
 # gRPC transport
-tonic             = { version = "0.14", default-features = false, features = ["channel", "codegen"] }
+# tls-ring: pure-Rust rustls backend using the `ring` crypto provider.
+# tls-native-roots: pick up the OS trust store as the default root set.
+tonic             = { version = "0.14", default-features = false, features = ["channel", "codegen", "tls-ring", "tls-native-roots"] }
 tonic-reflection  = { version = "0.14", default-features = false }
+
+# Exposed so we can install the `ring` crypto provider exactly once at
+# _PG_init — the first TLS handshake would otherwise pick lazily and panic
+# if multiple providers are compiled in.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 # Protobuf encode/decode + dynamic reflection
 prost         = "0.14"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ SELECT grpc_call(
 );
 ```
 
+### 3. TLS (optional)
+
+Pass a non-null `tls` JSONB to negotiate TLS. The OS trust store is used by default, so the public example below needs no extra configuration:
+
+```sql
+SELECT grpc_call(
+    'grpcb.in:9001',
+    'grpcbin.GRPCBin/DummyUnary',
+    '{"f_string": "hello"}'::jsonb,
+    tls => '{}'::jsonb
+);
+```
+
+For private CAs, layer in a PEM via `ca_cert`:
+
+```sql
+SELECT grpc_call(
+    'internal.example.com:443',
+    'pkg.Service/Method',
+    '{"foo": "bar"}'::jsonb,
+    tls => jsonb_build_object('ca_cert', pg_read_file('/etc/ssl/certs/internal-root.pem'))
+);
+```
+
 ## Proto management API
 
 | Function                              | Description                                |
@@ -85,9 +109,8 @@ All errors raise a PostgreSQL `ERROR` and abort the current statement:
 
 ## Limitations
 
-- **HTTP only** — TLS/mTLS not supported
+- **Server-auth TLS only** — mTLS (`client_cert`, `client_key`) and SNI override (`domain_name`) are not wired yet
 - **Unary only** — streaming methods not supported
-- **No caching** — a new connection and (for the reflection path) a new reflection request are made on every call
-- **Endpoint format** — `host:port`, never include a scheme
+- **Endpoint format** — `host:port`, never include a scheme (the scheme is chosen by the `tls` parameter)
 - **Reflection** — required unless you use `grpc_proto_stage` + `grpc_proto_compile`
-- **Per-connection state** — the staged/registered protos live inside a single Postgres backend; new connections start empty
+- **Per-connection state** — channel cache, staged, and registered protos all live inside a single Postgres backend; new connections start empty

--- a/src/call.rs
+++ b/src/call.rs
@@ -10,6 +10,7 @@ use tonic::transport::Channel;
 use crate::channel_cache;
 use crate::error::{GrpcError, GrpcResult};
 use crate::proto;
+use crate::tls::TlsConfig;
 
 pub fn make_grpc_call(
     endpoint: &str,
@@ -18,6 +19,7 @@ pub fn make_grpc_call(
     use_reflection: bool,
     metadata: Option<serde_json::Value>,
     timeout_ms: u64,
+    tls: Option<TlsConfig>,
 ) -> GrpcResult<serde_json::Value> {
     // pgrx backends are single-threaded; a multi-thread runtime would unsafely cross the Postgres boundary.
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -27,7 +29,7 @@ pub fn make_grpc_call(
     rt.block_on(async {
         match tokio::time::timeout(
             std::time::Duration::from_millis(timeout_ms),
-            call_async(endpoint, method, request_json, use_reflection, metadata),
+            call_async(endpoint, method, request_json, use_reflection, metadata, tls),
         )
         .await
         {
@@ -43,9 +45,10 @@ async fn call_async(
     request_json: serde_json::Value,
     use_reflection: bool,
     metadata: Option<serde_json::Value>,
+    tls: Option<TlsConfig>,
 ) -> GrpcResult<serde_json::Value> {
     let (service_name, method_name) = parse_method(method)?;
-    let channel = channel_cache::get_or_connect(endpoint).await?;
+    let channel = channel_cache::get_or_connect(endpoint, tls.as_ref()).await?;
     let pool = match crate::proto_registry::get_proto(&service_name) {
         Some(pool) => pool,
         None if use_reflection => {

--- a/src/call.rs
+++ b/src/call.rs
@@ -29,7 +29,14 @@ pub fn make_grpc_call(
     rt.block_on(async {
         match tokio::time::timeout(
             std::time::Duration::from_millis(timeout_ms),
-            call_async(endpoint, method, request_json, use_reflection, metadata, tls),
+            call_async(
+                endpoint,
+                method,
+                request_json,
+                use_reflection,
+                metadata,
+                tls,
+            ),
         )
         .await
         {

--- a/src/channel_cache.rs
+++ b/src/channel_cache.rs
@@ -8,9 +8,7 @@ use crate::error::{GrpcError, GrpcResult};
 use crate::tls::TlsConfig;
 
 // Cache key is (endpoint, Option<TlsConfig>) so two calls with the same host
-// but different TLS settings (e.g. plaintext vs TLS, or different ca_cert)
-// resolve to distinct Channels. tonic::transport::Channel is Arc-backed, so
-// clones share one underlying connection pool and its auto-reconnect logic.
+// but different TLS settings resolve to distinct Channels.
 type Key = (String, Option<TlsConfig>);
 
 static CHANNELS: LazyLock<RwLock<HashMap<Key, Channel>>> =

--- a/src/channel_cache.rs
+++ b/src/channel_cache.rs
@@ -5,23 +5,42 @@ use tonic::transport::Channel;
 
 use crate::endpoint::validate_endpoint;
 use crate::error::{GrpcError, GrpcResult};
+use crate::tls::TlsConfig;
 
-// Process-global Channel cache, keyed by the validated endpoint string.
-// tonic::transport::Channel is Arc-backed, so clones share the same underlying
-// connection pool and HTTP/2 session, including its auto-reconnect behavior.
-static CHANNELS: LazyLock<RwLock<HashMap<String, Channel>>> =
+// Cache key is (endpoint, Option<TlsConfig>) so two calls with the same host
+// but different TLS settings (e.g. plaintext vs TLS, or different ca_cert)
+// resolve to distinct Channels. tonic::transport::Channel is Arc-backed, so
+// clones share one underlying connection pool and its auto-reconnect logic.
+type Key = (String, Option<TlsConfig>);
+
+static CHANNELS: LazyLock<RwLock<HashMap<Key, Channel>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-pub async fn get_or_connect(endpoint: &str) -> GrpcResult<Channel> {
-    let key = validate_endpoint(endpoint)?;
+pub async fn get_or_connect(endpoint: &str, tls: Option<&TlsConfig>) -> GrpcResult<Channel> {
+    let host = validate_endpoint(endpoint)?;
+    let key: Key = (host.clone(), tls.cloned());
+
     if let Some(channel) = CHANNELS.read().get(&key).cloned() {
         return Ok(channel);
     }
-    let channel = Channel::from_shared(format!("http://{key}"))
-        .map_err(|e| GrpcError::Connection(e.to_string()))?
+
+    // Scheme flips to https so tonic's transport negotiates ALPN/TLS; the
+    // host part is identical to the plaintext case.
+    let scheme = if tls.is_some() { "https" } else { "http" };
+    let mut builder = Channel::from_shared(format!("{scheme}://{host}"))
+        .map_err(|e| GrpcError::Connection(e.to_string()))?;
+
+    if let Some(tls_cfg) = tls {
+        builder = builder
+            .tls_config(tls_cfg.build_client_tls_config())
+            .map_err(|e| GrpcError::Connection(format!("TLS config: {e}")))?;
+    }
+
+    let channel = builder
         .connect()
         .await
-        .map_err(|e| GrpcError::Connection(format!("{key}: {e}")))?;
+        .map_err(|e| GrpcError::Connection(format!("{host}: {e}")))?;
+
     Ok(CHANNELS.write().entry(key).or_insert(channel).clone())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod proto;
 mod proto_registry;
 mod proto_staging;
+mod tls;
 
 use crate::error::{GrpcError, GrpcResult};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,20 @@ fn grpc_call(
     metadata: default!(Option<pgrx::JsonB>, "null"),
     timeout_ms: default!(Option<i64>, "null"),
     use_reflection: default!(Option<bool>, "true"),
+    tls: default!(Option<pgrx::JsonB>, "null"),
 ) -> pgrx::JsonB {
     let timeout_ms = match timeout_ms {
         Some(v) if v <= 0 => pgrx::error!("timeout_ms must be positive (got {})", v),
         Some(v) => v as u64,
         None => 30_000,
+    };
+    let tls_cfg = match tls {
+        None => None,
+        Some(pgrx::JsonB(serde_json::Value::Null)) => None,
+        Some(pgrx::JsonB(v)) => match tls::TlsConfig::parse(&v) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => pgrx::error!("{}", e),
+        },
     };
     match call::make_grpc_call(
         endpoint,
@@ -43,6 +52,7 @@ fn grpc_call(
         use_reflection.unwrap_or(true),
         metadata.map(|j| j.0),
         timeout_ms,
+        tls_cfg,
     ) {
         Ok(value) => pgrx::JsonB(value),
         Err(e) => pgrx::error!("{}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,15 @@ mod proto_registry;
 mod proto_staging;
 mod tls;
 
+// Called by Postgres once per backend when the extension library is first
+// loaded. Installs the rustls `ring` crypto provider so the first TLS
+// handshake cannot trigger a lazy-install panic or race. install_default
+// returns Err if a provider was already installed — harmless, ignored.
+#[pg_guard]
+pub extern "C-unwind" fn _PG_init() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 use crate::error::{GrpcError, GrpcResult};
 
 #[pg_extern]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,6 @@ mod proto_registry;
 mod proto_staging;
 mod tls;
 
-// Called by Postgres once per backend when the extension library is first
-// loaded. Installs the rustls `ring` crypto provider so the first TLS
-// handshake cannot trigger a lazy-install panic or race. install_default
-// returns Err if a provider was already installed — harmless, ignored.
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
     let _ = rustls::crypto::ring::default_provider().install_default();

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -9,6 +9,7 @@ fn test_grpc_call_dummyunary() {
         None,
         None,
         None,
+        None,
     );
     assert_eq!(result.0["f_string"], "hello");
 }
@@ -21,6 +22,7 @@ fn test_grpc_call_invalid_method_path() {
         &grpcbin_endpoint(),
         "no-slash-here",
         pgrx::JsonB(serde_json::json!({})),
+        None,
         None,
         None,
         None,
@@ -40,6 +42,7 @@ fn test_grpc_call_reflection_disabled_misses_registry() {
         None,
         None,
         Some(false),
+        None,
     );
 }
 
@@ -65,6 +68,7 @@ fn test_grpc_call_reflection_disabled_hits_registry() {
         None,
         None,
         Some(false),
+        None,
     );
     assert_eq!(result.0["f_string"], "no-reflection");
 
@@ -92,6 +96,7 @@ fn test_grpc_call_method_not_found() {
         None,
         None,
         None,
+        None,
     );
 }
 
@@ -106,6 +111,7 @@ fn test_grpc_call_with_metadata_smoke() {
             "authorization": "Bearer tok",
             "x-trace-id": "abc"
         }))),
+        None,
         None,
         None,
     );
@@ -248,6 +254,7 @@ fn test_grpc_call_timeout_fires() {
         None,
         Some(200),
         None,
+        None,
     );
 }
 
@@ -260,6 +267,7 @@ fn test_grpc_call_timeout_zero_rejected() {
         None,
         Some(0),
         None,
+        None,
     );
 }
 
@@ -271,6 +279,7 @@ fn test_grpc_call_timeout_negative_rejected() {
         pgrx::JsonB(serde_json::json!({"f_string": "hi"})),
         None,
         Some(-5),
+        None,
         None,
     );
 }

--- a/src/tests/channel_cache.rs
+++ b/src/tests/channel_cache.rs
@@ -7,7 +7,7 @@ fn test_channel_cache_first_lookup_stores_channel() {
         .unwrap();
     let endpoint = grpcbin_endpoint();
     rt.block_on(async {
-        crate::channel_cache::get_or_connect(&endpoint)
+        crate::channel_cache::get_or_connect(&endpoint, None)
             .await
             .expect("first lookup should connect");
     });
@@ -24,10 +24,10 @@ fn test_channel_cache_second_lookup_is_cache_hit() {
         .unwrap();
     let endpoint = grpcbin_endpoint();
     rt.block_on(async {
-        crate::channel_cache::get_or_connect(&endpoint)
+        crate::channel_cache::get_or_connect(&endpoint, None)
             .await
             .expect("first lookup should connect");
-        crate::channel_cache::get_or_connect(&endpoint)
+        crate::channel_cache::get_or_connect(&endpoint, None)
             .await
             .expect("second lookup should hit cache");
     });

--- a/src/tests/endpoint.rs
+++ b/src/tests/endpoint.rs
@@ -73,6 +73,7 @@ fn test_grpc_call_rejects_http_prefixed_endpoint() {
         None,
         None,
         None,
+        None,
     );
 }
 
@@ -82,6 +83,7 @@ fn test_grpc_call_rejects_empty_endpoint() {
         "",
         "pkg.Service/Method",
         pgrx::JsonB(serde_json::json!({})),
+        None,
         None,
         None,
         None,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,13 @@ mod tests {
         std::env::var("GRPCBIN_ENDPOINT").unwrap_or_else(|_| "grpcb.in:9000".to_string())
     }
 
+    // TLS sibling of grpcbin_endpoint. grpcb.in exposes :9001 as the TLS port.
+    // Allow override for CI where the containerized grpcbin may terminate TLS
+    // on a different host/port.
+    fn grpcbin_tls_endpoint() -> String {
+        std::env::var("GRPCBIN_TLS_ENDPOINT").unwrap_or_else(|_| "grpcb.in:9001".to_string())
+    }
+
     include!("call.rs");
     include!("channel_cache.rs");
     include!("compile.rs");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,4 +17,5 @@ mod tests {
     include!("list.rs");
     include!("registry.rs");
     include!("staging.rs");
+    include!("tls.rs");
 }

--- a/src/tests/registry.rs
+++ b/src/tests/registry.rs
@@ -53,6 +53,7 @@ fn test_registry_precedence_over_reflection() {
         None,
         None,
         None,
+        None,
     );
     assert_eq!(result.0["renamed_field"], "winner");
     assert!(

--- a/src/tests/staging.rs
+++ b/src/tests/staging.rs
@@ -22,6 +22,7 @@ fn test_grpc_proto_stage_single_file() {
         None,
         None,
         None,
+        None,
     );
     assert_eq!(result.0["f_string"], "via-registry");
 }
@@ -53,6 +54,7 @@ fn test_grpc_proto_stage_cross_import() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "multi-file"})),
+        None,
         None,
         None,
         None,
@@ -92,6 +94,7 @@ fn test_grpc_proto_unstage_recovers_bad_file() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "recovered"})),
+        None,
         None,
         None,
         None,

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -72,3 +72,49 @@ fn test_tls_config_empty_ne_with_ca_cert() {
         crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM" })).unwrap();
     assert_ne!(empty, with_ca);
 }
+
+// Cache-key distinctness at the (endpoint, Option<TlsConfig>) level. Exercises
+// the Hash/Eq contract directly rather than forcing real TLS handshakes —
+// different TLS configs must be different keys regardless of endpoint.
+#[pg_test]
+fn test_cache_key_same_endpoint_same_tls_eq() {
+    let endpoint = "host:9000".to_string();
+    let tls = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM" })).unwrap();
+    let k1 = (endpoint.clone(), Some(tls.clone()));
+    let k2 = (endpoint, Some(tls));
+    assert_eq!(k1, k2);
+}
+
+#[pg_test]
+fn test_cache_key_same_endpoint_different_tls_ne() {
+    let endpoint = "host:9000".to_string();
+    let a = crate::tls::TlsConfig::parse(&serde_json::json!({})).unwrap();
+    let b = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM" })).unwrap();
+    let k_plain = (endpoint.clone(), None::<crate::tls::TlsConfig>);
+    let k_tls_empty = (endpoint.clone(), Some(a));
+    let k_tls_ca = (endpoint, Some(b));
+    assert_ne!(k_plain, k_tls_empty);
+    assert_ne!(k_tls_empty, k_tls_ca);
+    assert_ne!(k_plain, k_tls_ca);
+}
+
+// End-to-end: real TLS handshake + reflection + unary call against grpcb.in:9001
+// using the system trust store. Matches how the existing plaintext tests hit
+// grpcb.in:9000 — relies on outbound network, same as the rest of the suite.
+#[pg_test]
+fn test_grpc_call_tls_reflection_e2e() {
+    crate::grpc_proto_unregister_all();
+    crate::channel_cache::clear();
+    let result = crate::grpc_call(
+        &grpcbin_tls_endpoint(),
+        "grpcbin.GRPCBin/DummyUnary",
+        pgrx::JsonB(serde_json::json!({"f_string": "tls-hello"})),
+        None,
+        None,
+        None,
+        Some(pgrx::JsonB(serde_json::json!({}))),
+    );
+    assert_eq!(result.0["f_string"], "tls-hello");
+    crate::grpc_proto_unregister_all();
+    crate::channel_cache::clear();
+}

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -1,0 +1,74 @@
+#[pg_test]
+fn test_tls_parse_empty_object_uses_system_roots() {
+    let cfg = crate::tls::TlsConfig::parse(&serde_json::json!({})).unwrap();
+    assert!(cfg.ca_cert.is_none());
+}
+
+#[pg_test]
+fn test_tls_parse_with_ca_cert() {
+    let pem = "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n";
+    let cfg =
+        crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": pem })).unwrap();
+    assert_eq!(cfg.ca_cert.as_deref(), Some(pem.as_bytes()));
+}
+
+#[pg_test]
+fn test_tls_parse_rejects_unknown_key() {
+    let err =
+        crate::tls::TlsConfig::parse(&serde_json::json!({ "client_cert": "x" }))
+            .expect_err("unknown key must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown key"), "unexpected: {msg}");
+    assert!(msg.contains("ca_cert"), "should list accepted fields: {msg}");
+}
+
+#[pg_test]
+fn test_tls_parse_rejects_empty_ca_cert() {
+    let err = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "" }))
+        .expect_err("empty ca_cert must fail");
+    assert!(err.to_string().contains("must not be empty"), "{err}");
+}
+
+#[pg_test]
+fn test_tls_parse_rejects_non_object() {
+    crate::tls::TlsConfig::parse(&serde_json::json!("plain-string"))
+        .expect_err("non-object must fail");
+    crate::tls::TlsConfig::parse(&serde_json::json!([1, 2, 3]))
+        .expect_err("array must fail");
+    crate::tls::TlsConfig::parse(&serde_json::json!(42)).expect_err("number must fail");
+}
+
+#[pg_test]
+fn test_tls_parse_rejects_non_string_ca_cert() {
+    crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": 42 }))
+        .expect_err("non-string ca_cert must fail");
+}
+
+#[pg_test]
+fn test_tls_parse_null_ca_cert_treated_as_absent() {
+    let cfg =
+        crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": null })).unwrap();
+    assert!(cfg.ca_cert.is_none());
+}
+
+#[pg_test]
+fn test_tls_config_eq_same_ca_cert() {
+    let a = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM" })).unwrap();
+    let b = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM" })).unwrap();
+    assert_eq!(a, b);
+}
+
+#[pg_test]
+fn test_tls_config_ne_different_ca_cert() {
+    let a = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM-A" })).unwrap();
+    let b = crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM-B" })).unwrap();
+    assert_ne!(a, b);
+}
+
+#[pg_test]
+fn test_tls_config_empty_ne_with_ca_cert() {
+    let empty = crate::tls::TlsConfig::parse(&serde_json::json!({})).unwrap();
+    let with_ca =
+        crate::tls::TlsConfig::parse(&serde_json::json!({ "ca_cert": "PEM" })).unwrap();
+    assert_ne!(empty, with_ca);
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -5,9 +5,6 @@ use crate::error::{GrpcError, GrpcResult};
 
 const ACCEPTED_FIELDS: &[&str] = &["ca_cert"];
 
-// Parsed server-auth TLS options. Hash+Eq so two calls with the same TLS
-// configuration share a cached Channel via the (endpoint, Option<TlsConfig>)
-// key, while differing configs resolve to distinct entries.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct TlsConfig {
     pub ca_cert: Option<Vec<u8>>,
@@ -52,13 +49,10 @@ impl TlsConfig {
         Ok(Self { ca_cert })
     }
 
-    // with_native_roots seeds the OS trust store; ca_certificate layers in a
-    // private-CA PEM on top, which is what private deployments need when the
-    // server cert is not chained to a publicly-trusted root.
     pub fn build_client_tls_config(&self) -> ClientTlsConfig {
         let mut cfg = ClientTlsConfig::new().with_native_roots();
-        if let Some(pem) = &self.ca_cert {
-            cfg = cfg.ca_certificate(Certificate::from_pem(pem.clone()));
+        if let Some(ca_cert) = &self.ca_cert {
+            cfg = cfg.ca_certificate(Certificate::from_pem(ca_cert.clone()));
         }
         cfg
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,65 @@
+use serde_json::Value;
+use tonic::transport::{Certificate, ClientTlsConfig};
+
+use crate::error::{GrpcError, GrpcResult};
+
+const ACCEPTED_FIELDS: &[&str] = &["ca_cert"];
+
+// Parsed server-auth TLS options. Hash+Eq so two calls with the same TLS
+// configuration share a cached Channel via the (endpoint, Option<TlsConfig>)
+// key, while differing configs resolve to distinct entries.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct TlsConfig {
+    pub ca_cert: Option<Vec<u8>>,
+}
+
+impl TlsConfig {
+    pub fn parse(value: &Value) -> GrpcResult<Self> {
+        let obj = match value {
+            Value::Object(m) => m,
+            _ => {
+                return Err(GrpcError::Connection(format!(
+                    "tls must be a JSON object (accepted fields: {})",
+                    ACCEPTED_FIELDS.join(", ")
+                )));
+            }
+        };
+
+        for key in obj.keys() {
+            if !ACCEPTED_FIELDS.contains(&key.as_str()) {
+                return Err(GrpcError::Connection(format!(
+                    "tls: unknown key '{key}' (accepted fields: {})",
+                    ACCEPTED_FIELDS.join(", ")
+                )));
+            }
+        }
+
+        let ca_cert = match obj.get("ca_cert") {
+            None | Some(Value::Null) => None,
+            Some(Value::String(s)) if s.is_empty() => {
+                return Err(GrpcError::Connection(
+                    "tls: ca_cert must not be empty".into(),
+                ));
+            }
+            Some(Value::String(s)) => Some(s.as_bytes().to_vec()),
+            Some(_) => {
+                return Err(GrpcError::Connection(
+                    "tls: ca_cert must be a PEM string".into(),
+                ));
+            }
+        };
+
+        Ok(Self { ca_cert })
+    }
+
+    // with_native_roots seeds the OS trust store; ca_certificate layers in a
+    // private-CA PEM on top, which is what private deployments need when the
+    // server cert is not chained to a publicly-trusted root.
+    pub fn build_client_tls_config(&self) -> ClientTlsConfig {
+        let mut cfg = ClientTlsConfig::new().with_native_roots();
+        if let Some(pem) = &self.ca_cert {
+            cfg = cfg.ca_certificate(Certificate::from_pem(pem.clone()));
+        }
+        cfg
+    }
+}


### PR DESCRIPTION
Closes #41.

## Summary
- Adds a trailing `tls JSONB DEFAULT NULL` parameter to `grpc_call`. `NULL` keeps current plaintext behavior; `'{}'::jsonb` enables TLS with the OS trust store; `'{"ca_cert": "<PEM>"}'::jsonb` layers in a private-CA root.
- New `src/tls.rs` parses the JSONB strictly (unknown keys / empty-string values rejected, `null` treated as absent) into a `Hash + Eq` `TlsConfig`, which now keys the channel cache as `(endpoint, Option<TlsConfig>)`.
- `_PG_init` installs the rustls `ring` crypto provider once per backend to avoid any lazy-install race on the first handshake.
- Enables tonic's `tls-ring` + `tls-native-roots` features; reflection runs over the same channel, so `use_reflection => true` + `tls => '{...}'` reflects over TLS automatically.
- `GrpcError::Connection` carries all TLS errors — no new variants.
- mTLS (`client_cert` / `client_key`) and SNI override (`domain_name`) are intentionally out of scope for this slice per #41.

## Test plan
- [x] `cargo pgrx test pg18` — 92/92 green, incl. real TLS handshake + reflection against `grpcb.in:9001`
- [x] `cargo clippy -- -D warnings` clean on both `pg18` and `pg18 pg_test`
- [x] `cargo fmt --check`
- [x] Unit tests: unknown-key rejection, empty-string rejection, non-object rejection, null-treated-as-absent, valid empty, valid with `ca_cert`, `TlsConfig` Hash/Eq
- [x] Cache-key distinctness for same-endpoint-different-TLS and same-endpoint-same-TLS
- [x] E2E `#[pg_test]` against `grpcb.in:9001` via reflection using system roots

## Docs
- README: TLS quickstart block + private-CA example; "HTTP only" and "No caching" limitation bullets removed.
- CLAUDE.md: `tls` added to SQL signature, proto-resolution flow, API summary, and project-structure tree; `_PG_init` noted.