### PR TITLE
Feat/call options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 tests/pg_regress/results
 tests/pg_regress/regression.diffs
 tests/pg_regress/regression.out
+.scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,15 +115,38 @@ fn grpc_call(
     method: &str,
     request: pgrx::JsonB,
     metadata: default!(Option<pgrx::JsonB>, "null"),   // gRPC metadata / headers
-    timeout_ms: default!(Option<i64>, "null"),         // defaults to 30_000ms; must be > 0
-    use_reflection: default!(Option<bool>, "true"),
-    tls: default!(Option<pgrx::JsonB>, "null"),        // NULL → plaintext; object → TLS
+    options: default!(Option<pgrx::JsonB>, "null"),    // transport / runtime knobs
 ) -> pgrx::JsonB
 ```
 
 `metadata` is a JSON object whose values are strings or arrays of strings. Keys are silently lowercased. Keys ending in `-bin` (binary metadata) are rejected in v1.
 
-`tls` controls transport security. `NULL` (default) keeps the current plaintext behavior; `'{}'::jsonb` turns on TLS with the OS trust store; `'{"ca_cert": "<PEM>"}'::jsonb` adds a private-CA root on top. Reflection runs over the same channel, so `use_reflection => true` with a non-null `tls` reflects over TLS. Parsing is strict: unknown keys and empty- or whitespace-only string values raise a `Connection error`. The accepted fields are `ca_cert`, `client_cert`, `client_key`, and `domain_name`. For mTLS, `client_cert` and `client_key` must be set together (one without the other is a parse error); when both are present they're attached as a tonic `Identity`. `domain_name` overrides the SNI / certificate-verification name — needed for IP endpoints or when the server cert's CN/SAN doesn't match the dialed host.
+`options` is a strict-parsed JSONB blob holding all per-call transport/runtime config. `NULL` or omitted keys leave defaults in place. Unknown keys raise a `Connection error` listing the accepted set, and per-key type/range errors carry the offending path (e.g. `options.timeout_ms must be an integer`). Accepted keys:
+
+| Key                              | Type    | Validation                | Default behavior when omitted                 |
+| -------------------------------- | ------- | ------------------------- | --------------------------------------------- |
+| `timeout_ms`                     | integer | `>= 1`                    | 30_000 ms                                     |
+| `use_reflection`                 | boolean | —                         | `true`                                        |
+| `tls`                            | object  | delegated to TLS parser   | NULL → plaintext                              |
+| `max_decode_message_size_bytes`  | integer | `[1, 4_294_967_295]`      | tonic default (4 MiB)                         |
+| `max_encode_message_size_bytes`  | integer | `[1, 4_294_967_295]`      | tonic default (unbounded)                     |
+
+Example mixing several keys:
+
+```sql
+SELECT grpc_call('host:port', 'pkg.S/M', '{}'::jsonb,
+  options => '{
+    "timeout_ms": 5000,
+    "use_reflection": true,
+    "tls": {"ca_cert": "<PEM>"},
+    "max_decode_message_size_bytes": 67108864,
+    "max_encode_message_size_bytes": 4194304
+  }'::jsonb);
+```
+
+The size knobs apply to both the unary call and the reflection fetch on the same channel — a generous decode limit lets you both receive a large response and reflect a large schema. The 4_294_967_295 ceiling is the gRPC wire framing limit (4-byte length prefix); larger values can never be a valid single-message size.
+
+`tls` (when supplied) controls transport security. `'{}'::jsonb` turns on TLS with the OS trust store; `'{"ca_cert": "<PEM>"}'::jsonb` adds a private-CA root on top. Reflection runs over the same channel, so `use_reflection => true` with a non-null `tls` reflects over TLS. The accepted inner fields are `ca_cert`, `client_cert`, `client_key`, and `domain_name`. For mTLS, `client_cert` and `client_key` must be set together (one without the other is a parse error); when both are present they're attached as a tonic `Identity`. `domain_name` overrides the SNI / certificate-verification name — needed for IP endpoints or when the server cert's CN/SAN doesn't match the dialed host.
 
 User-supplied proto management (all `#[pg_extern]` in lib.rs):
 
@@ -317,7 +340,8 @@ Tests share a single backend process, so the `PROTO_REGISTRY` and `PENDING_FILES
 
 ```sql
 -- gRPC call
-grpc_call(endpoint TEXT, method TEXT, request JSONB [, metadata JSONB] [, timeout_ms BIGINT] [, use_reflection BOOLEAN] [, tls JSONB]) RETURNS JSONB
+grpc_call(endpoint TEXT, method TEXT, request JSONB [, metadata JSONB] [, options JSONB]) RETURNS JSONB
+-- options keys: timeout_ms, use_reflection, tls, max_decode_message_size_bytes, max_encode_message_size_bytes
 
 -- Staging
 grpc_proto_stage(filename TEXT, source TEXT) RETURNS VOID

--- a/README.md
+++ b/README.md
@@ -57,16 +57,31 @@ SELECT grpc_call(
 );
 ```
 
-### 3. TLS (optional)
+### 3. Per-call options
 
-Pass a non-null `tls` JSONB to negotiate TLS. The OS trust store is used by default, so the public example below needs no extra configuration:
+Per-call settings (timeout, TLS, reflection toggle, message size limits) all go
+inside a single `options` JSONB blob, separate from `metadata` (gRPC headers).
+Omit the blob — or any individual key — to take defaults.
+
+| `options` key                    | Type    | Default                  |
+| -------------------------------- | ------- | ------------------------ |
+| `timeout_ms`                     | integer | 30000                    |
+| `use_reflection`                 | boolean | true                     |
+| `tls`                            | object  | NULL → plaintext         |
+| `max_decode_message_size_bytes`  | integer | 4 MiB (tonic default)    |
+| `max_encode_message_size_bytes`  | integer | unbounded (tonic default)|
+
+### TLS
+
+Set `options.tls` to negotiate TLS. The OS trust store is used by default, so
+the public example below needs no extra configuration:
 
 ```sql
 SELECT grpc_call(
     'grpcb.in:9001',
     'grpcbin.GRPCBin/DummyUnary',
     '{"f_string": "hello"}'::jsonb,
-    tls => '{}'::jsonb
+    options => '{"tls": {}}'::jsonb
 );
 ```
 
@@ -77,7 +92,9 @@ SELECT grpc_call(
     'internal.example.com:443',
     'pkg.Service/Method',
     '{"foo": "bar"}'::jsonb,
-    tls => jsonb_build_object('ca_cert', pg_read_file('/etc/ssl/certs/internal-root.pem'))
+    options => jsonb_build_object(
+        'tls', jsonb_build_object('ca_cert', pg_read_file('/etc/ssl/certs/internal-root.pem'))
+    )
 );
 ```
 
@@ -90,12 +107,27 @@ SELECT grpc_call(
     '10.0.0.7:8443',
     'pkg.Service/Method',
     '{"foo": "bar"}'::jsonb,
-    tls => jsonb_build_object(
+    options => jsonb_build_object('tls', jsonb_build_object(
         'ca_cert',     pg_read_file('/etc/ssl/certs/internal-root.pem'),
         'client_cert', pg_read_file('/etc/ssl/certs/client.pem'),
         'client_key',  pg_read_file('/etc/ssl/private/client.key'),
         'domain_name', 'internal.example.com'
-    )
+    ))
+);
+```
+
+### Large messages
+
+Raise tonic's 4 MiB decode cap (and/or set an encode guardrail) per call. Limits
+are in raw bytes and apply to both the unary call and the reflection fetch on
+the same channel:
+
+```sql
+SELECT grpc_call(
+    'host:port',
+    'pkg.Service/GetLargeThing',
+    '{}'::jsonb,
+    options => '{"max_decode_message_size_bytes": 67108864}'::jsonb
 );
 ```
 
@@ -123,7 +155,7 @@ All errors raise a PostgreSQL `ERROR` and abort the current statement:
 | `Proto error: …`         | Reflection failed, symbol not found, or JSON ↔ protobuf encode/decode error |
 | `Proto compile error: …` | `grpc_proto_compile` failed to parse/resolve the staged files               |
 | `gRPC call failed: …`    | Server returned a non-OK gRPC status                                        |
-| `Request timeout: …ms`   | The call (connect + reflection + unary) did not finish within `timeout_ms`  |
+| `Request timeout: …ms`   | The call (connect + reflection + unary) did not finish within `options.timeout_ms` |
 
 ## Limitations
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -12,6 +12,7 @@ use crate::error::{GrpcError, GrpcResult};
 use crate::proto;
 use crate::tls::TlsConfig;
 
+#[allow(clippy::too_many_arguments)]
 pub fn make_grpc_call(
     endpoint: &str,
     method: &str,
@@ -67,8 +68,7 @@ async fn call_async(
         Some(pool) => pool,
         None if use_reflection => {
             let pool =
-                proto::fetch_pool(channel.clone(), &service_name, max_decode, max_encode)
-                    .await?;
+                proto::fetch_pool(channel.clone(), &service_name, max_decode, max_encode).await?;
             crate::proto_registry::insert_proto_reflection(
                 &service_name,
                 pool.clone(),

--- a/src/call.rs
+++ b/src/call.rs
@@ -20,6 +20,8 @@ pub fn make_grpc_call(
     metadata: Option<serde_json::Value>,
     timeout_ms: u64,
     tls: Option<TlsConfig>,
+    max_decode_message_size_bytes: Option<u32>,
+    max_encode_message_size_bytes: Option<u32>,
 ) -> GrpcResult<serde_json::Value> {
     // pgrx backends are single-threaded; a multi-thread runtime would unsafely cross the Postgres boundary.
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -36,6 +38,8 @@ pub fn make_grpc_call(
                 use_reflection,
                 metadata,
                 tls,
+                max_decode_message_size_bytes,
+                max_encode_message_size_bytes,
             ),
         )
         .await
@@ -46,6 +50,7 @@ pub fn make_grpc_call(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn call_async(
     endpoint: &str,
     method: &str,
@@ -53,13 +58,17 @@ async fn call_async(
     use_reflection: bool,
     metadata: Option<serde_json::Value>,
     tls: Option<TlsConfig>,
+    max_decode: Option<u32>,
+    max_encode: Option<u32>,
 ) -> GrpcResult<serde_json::Value> {
     let (service_name, method_name) = parse_method(method)?;
     let channel = channel_cache::get_or_connect(endpoint, tls.as_ref()).await?;
     let pool = match crate::proto_registry::get_proto(&service_name) {
         Some(pool) => pool,
         None if use_reflection => {
-            let pool = proto::fetch_pool(channel.clone(), &service_name).await?;
+            let pool =
+                proto::fetch_pool(channel.clone(), &service_name, max_decode, max_encode)
+                    .await?;
             crate::proto_registry::insert_proto_reflection(
                 &service_name,
                 pool.clone(),
@@ -81,6 +90,8 @@ async fn call_async(
         &method_name,
         request_bytes,
         metadata,
+        max_decode,
+        max_encode,
     )
     .await?;
     decode_response(method_desc.output(), response_bytes)
@@ -132,12 +143,20 @@ async fn unary_call(
     method_name: &str,
     body: Bytes,
     metadata: Option<serde_json::Value>,
+    max_decode: Option<u32>,
+    max_encode: Option<u32>,
 ) -> GrpcResult<Bytes> {
     let path = format!("/{service_name}/{method_name}")
         .parse::<http::uri::PathAndQuery>()
         .map_err(|e| GrpcError::Proto(e.to_string()))?;
 
     let mut grpc = tonic::client::Grpc::new(channel);
+    if let Some(n) = max_decode {
+        grpc = grpc.max_decoding_message_size(n as usize);
+    }
+    if let Some(n) = max_encode {
+        grpc = grpc.max_encoding_message_size(n as usize);
+    }
     grpc.ready()
         .await
         .map_err(|e| GrpcError::Connection(e.to_string()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,20 +25,12 @@ fn grpc_call(
     method: &str,
     request: pgrx::JsonB,
     metadata: default!(Option<pgrx::JsonB>, "null"),
-    timeout_ms: default!(Option<i64>, "null"),
-    use_reflection: default!(Option<bool>, "true"),
-    tls: default!(Option<pgrx::JsonB>, "null"),
+    options: default!(Option<pgrx::JsonB>, "null"),
 ) -> pgrx::JsonB {
-    let timeout_ms = match timeout_ms {
-        Some(v) if v <= 0 => pgrx::error!("timeout_ms must be positive (got {})", v),
-        Some(v) => v as u64,
-        None => 30_000,
-    };
-    let tls_cfg = match tls {
-        None => None,
-        Some(pgrx::JsonB(serde_json::Value::Null)) => None,
-        Some(pgrx::JsonB(v)) => match tls::TlsConfig::parse(&v) {
-            Ok(cfg) => Some(cfg),
+    let opts = match options {
+        None => options::OptionsConfig::default(),
+        Some(pgrx::JsonB(v)) => match options::OptionsConfig::parse(&v) {
+            Ok(c) => c,
             Err(e) => pgrx::error!("{}", e),
         },
     };
@@ -46,10 +38,10 @@ fn grpc_call(
         endpoint,
         method,
         request.0,
-        use_reflection.unwrap_or(true),
+        opts.use_reflection.unwrap_or(true),
         metadata.map(|j| j.0),
-        timeout_ms,
-        tls_cfg,
+        opts.timeout_ms.unwrap_or(30_000),
+        opts.tls,
     ) {
         Ok(value) => pgrx::JsonB(value),
         Err(e) => pgrx::error!("{}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod call;
 mod channel_cache;
 mod endpoint;
 mod error;
+mod options;
 mod proto;
 mod proto_registry;
 mod proto_staging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ fn grpc_call(
         metadata.map(|j| j.0),
         opts.timeout_ms.unwrap_or(30_000),
         opts.tls,
+        opts.max_decode_message_size_bytes,
+        opts.max_encode_message_size_bytes,
     ) {
         Ok(value) => pgrx::JsonB(value),
         Err(e) => pgrx::error!("{}", e),

--- a/src/options.rs
+++ b/src/options.rs
@@ -26,7 +26,7 @@ impl OptionsConfig {
             Value::Null => return Ok(Self::default()),
             Value::Object(m) => m,
             _ => {
-                return Err(GrpcError::Call(format!(
+                return Err(GrpcError::Connection(format!(
                     "options must be a JSON object (accepted keys: {})",
                     ACCEPTED_KEYS.join(", ")
                 )));
@@ -35,7 +35,7 @@ impl OptionsConfig {
 
         for key in obj.keys() {
             if !ACCEPTED_KEYS.contains(&key.as_str()) {
-                return Err(GrpcError::Call(format!(
+                return Err(GrpcError::Connection(format!(
                     "options: unknown key '{key}' (accepted keys: {})",
                     ACCEPTED_KEYS.join(", ")
                 )));
@@ -54,7 +54,7 @@ impl OptionsConfig {
                 Value::Null => None,
                 Value::Object(_) => Some(TlsConfig::parse(v)?),
                 _ => {
-                    return Err(GrpcError::Call(
+                    return Err(GrpcError::Connection(
                         "options.tls must be an object".to_string(),
                     ));
                 }
@@ -77,15 +77,15 @@ impl OptionsConfig {
 fn parse_size_u32(key: &str, value: &Value) -> GrpcResult<u32> {
     let n = value
         .as_i64()
-        .ok_or_else(|| GrpcError::Call(format!("options.{key} must be an integer")))?;
+        .ok_or_else(|| GrpcError::Connection(format!("options.{key} must be an integer")))?;
     if n < 1 {
-        return Err(GrpcError::Call(format!(
+        return Err(GrpcError::Connection(format!(
             "options.{key} must be in [1, {}] (got {n})",
             u32::MAX
         )));
     }
     if n > u32::MAX as i64 {
-        return Err(GrpcError::Call(format!(
+        return Err(GrpcError::Connection(format!(
             "options.{key} must be in [1, {}] (got {n})",
             u32::MAX
         )));
@@ -96,15 +96,15 @@ fn parse_size_u32(key: &str, value: &Value) -> GrpcResult<u32> {
 fn parse_bool(key: &str, value: &Value) -> GrpcResult<bool> {
     value
         .as_bool()
-        .ok_or_else(|| GrpcError::Call(format!("options.{key} must be a boolean")))
+        .ok_or_else(|| GrpcError::Connection(format!("options.{key} must be a boolean")))
 }
 
 fn parse_positive_u64(key: &str, value: &Value) -> GrpcResult<u64> {
     let n = value
         .as_i64()
-        .ok_or_else(|| GrpcError::Call(format!("options.{key} must be an integer")))?;
+        .ok_or_else(|| GrpcError::Connection(format!("options.{key} must be an integer")))?;
     if n < 1 {
-        return Err(GrpcError::Call(format!(
+        return Err(GrpcError::Connection(format!(
             "options.{key} must be >= 1 (got {n})"
         )));
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -24,8 +24,28 @@ impl OptionsConfig {
         if let Some(v) = obj.get("timeout_ms") {
             cfg.timeout_ms = Some(parse_positive_u64("timeout_ms", v)?);
         }
+        if let Some(v) = obj.get("use_reflection") {
+            cfg.use_reflection = Some(parse_bool("use_reflection", v)?);
+        }
+        if let Some(v) = obj.get("tls") {
+            cfg.tls = match v {
+                Value::Null => None,
+                Value::Object(_) => Some(TlsConfig::parse(v)?),
+                _ => {
+                    return Err(GrpcError::Call(
+                        "options.tls must be an object".to_string(),
+                    ));
+                }
+            };
+        }
         Ok(cfg)
     }
+}
+
+fn parse_bool(key: &str, value: &Value) -> GrpcResult<bool> {
+    value
+        .as_bool()
+        .ok_or_else(|| GrpcError::Call(format!("options.{key} must be a boolean")))
 }
 
 fn parse_positive_u64(key: &str, value: &Value) -> GrpcResult<u64> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::error::GrpcResult;
+use crate::error::{GrpcError, GrpcResult};
 use crate::tls::TlsConfig;
 
 #[derive(Debug, Default)]
@@ -14,10 +14,28 @@ pub struct OptionsConfig {
 
 impl OptionsConfig {
     pub fn parse(value: &Value) -> GrpcResult<Self> {
-        match value {
-            Value::Null => Ok(Self::default()),
-            Value::Object(_) => Ok(Self::default()),
+        let obj = match value {
+            Value::Null => return Ok(Self::default()),
+            Value::Object(m) => m,
             _ => unreachable!("non-null/non-object handled in later cycle"),
+        };
+
+        let mut cfg = Self::default();
+        if let Some(v) = obj.get("timeout_ms") {
+            cfg.timeout_ms = Some(parse_positive_u64("timeout_ms", v)?);
         }
+        Ok(cfg)
     }
+}
+
+fn parse_positive_u64(key: &str, value: &Value) -> GrpcResult<u64> {
+    let n = value
+        .as_i64()
+        .ok_or_else(|| GrpcError::Call(format!("options.{key} must be an integer")))?;
+    if n < 1 {
+        return Err(GrpcError::Call(format!(
+            "options.{key} must be >= 1 (got {n})"
+        )));
+    }
+    Ok(n as u64)
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,6 +3,14 @@ use serde_json::Value;
 use crate::error::{GrpcError, GrpcResult};
 use crate::tls::TlsConfig;
 
+const ACCEPTED_KEYS: &[&str] = &[
+    "timeout_ms",
+    "use_reflection",
+    "tls",
+    "max_decode_message_size_bytes",
+    "max_encode_message_size_bytes",
+];
+
 #[derive(Debug, Default)]
 pub struct OptionsConfig {
     pub timeout_ms: Option<u64>,
@@ -17,8 +25,22 @@ impl OptionsConfig {
         let obj = match value {
             Value::Null => return Ok(Self::default()),
             Value::Object(m) => m,
-            _ => unreachable!("non-null/non-object handled in later cycle"),
+            _ => {
+                return Err(GrpcError::Call(format!(
+                    "options must be a JSON object (accepted keys: {})",
+                    ACCEPTED_KEYS.join(", ")
+                )));
+            }
         };
+
+        for key in obj.keys() {
+            if !ACCEPTED_KEYS.contains(&key.as_str()) {
+                return Err(GrpcError::Call(format!(
+                    "options: unknown key '{key}' (accepted keys: {})",
+                    ACCEPTED_KEYS.join(", ")
+                )));
+            }
+        }
 
         let mut cfg = Self::default();
         if let Some(v) = obj.get("timeout_ms") {

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,8 +38,37 @@ impl OptionsConfig {
                 }
             };
         }
+        if let Some(v) = obj.get("max_decode_message_size_bytes") {
+            cfg.max_decode_message_size_bytes =
+                Some(parse_size_u32("max_decode_message_size_bytes", v)?);
+        }
+        if let Some(v) = obj.get("max_encode_message_size_bytes") {
+            cfg.max_encode_message_size_bytes =
+                Some(parse_size_u32("max_encode_message_size_bytes", v)?);
+        }
         Ok(cfg)
     }
+}
+
+// gRPC's wire framing uses a 4-byte length prefix; values above u32::MAX
+// can never be a valid single-message size.
+fn parse_size_u32(key: &str, value: &Value) -> GrpcResult<u32> {
+    let n = value
+        .as_i64()
+        .ok_or_else(|| GrpcError::Call(format!("options.{key} must be an integer")))?;
+    if n < 1 {
+        return Err(GrpcError::Call(format!(
+            "options.{key} must be in [1, {}] (got {n})",
+            u32::MAX
+        )));
+    }
+    if n > u32::MAX as i64 {
+        return Err(GrpcError::Call(format!(
+            "options.{key} must be in [1, {}] (got {n})",
+            u32::MAX
+        )));
+    }
+    Ok(n as u32)
 }
 
 fn parse_bool(key: &str, value: &Value) -> GrpcResult<bool> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,23 @@
+use serde_json::Value;
+
+use crate::error::GrpcResult;
+use crate::tls::TlsConfig;
+
+#[derive(Debug, Default)]
+pub struct OptionsConfig {
+    pub timeout_ms: Option<u64>,
+    pub use_reflection: Option<bool>,
+    pub tls: Option<TlsConfig>,
+    pub max_decode_message_size_bytes: Option<u32>,
+    pub max_encode_message_size_bytes: Option<u32>,
+}
+
+impl OptionsConfig {
+    pub fn parse(value: &Value) -> GrpcResult<Self> {
+        match value {
+            Value::Null => Ok(Self::default()),
+            Value::Object(_) => Ok(Self::default()),
+            _ => unreachable!("non-null/non-object handled in later cycle"),
+        }
+    }
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -8,13 +8,18 @@ use tonic::transport::Channel;
 
 use crate::error::{GrpcError, GrpcResult};
 
-pub async fn fetch_pool(channel: Channel, service_name: &str) -> GrpcResult<DescriptorPool> {
+pub async fn fetch_pool(
+    channel: Channel,
+    service_name: &str,
+    max_decode: Option<u32>,
+    max_encode: Option<u32>,
+) -> GrpcResult<DescriptorPool> {
     // Prefer the stable v1 service (grpc.reflection.v1.ServerReflection).
     // Fall back to v1alpha if the server hasn't implemented v1 yet.
-    match fetch_v1(channel.clone(), service_name).await {
+    match fetch_v1(channel.clone(), service_name, max_decode, max_encode).await {
         Ok(pool) => Ok(pool),
         Err(s) if s.code() == tonic::Code::Unimplemented => {
-            fetch_v1alpha(channel, service_name).await
+            fetch_v1alpha(channel, service_name, max_decode, max_encode).await
         }
         Err(s) => Err(s),
     }
@@ -26,6 +31,8 @@ macro_rules! define_fetch {
         async fn $name(
             channel: Channel,
             service_name: &str,
+            max_decode: Option<u32>,
+            max_encode: Option<u32>,
         ) -> Result<DescriptorPool, tonic::Status> {
             use $pb::{
                 server_reflection_client::ServerReflectionClient,
@@ -34,6 +41,12 @@ macro_rules! define_fetch {
             };
 
             let mut client = ServerReflectionClient::new(channel);
+            if let Some(n) = max_decode {
+                client = client.max_decoding_message_size(n as usize);
+            }
+            if let Some(n) = max_encode {
+                client = client.max_encoding_message_size(n as usize);
+            }
             let request = ServerReflectionRequest {
                 host: String::new(),
                 message_request: Some(MessageRequest::FileContainingSymbol(

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -8,8 +8,6 @@ fn test_grpc_call_dummyunary() {
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
         None,
-        None,
-        None,
     );
     assert_eq!(result.0["f_string"], "hello");
 }
@@ -22,8 +20,6 @@ fn test_grpc_call_invalid_method_path() {
         &grpcbin_endpoint(),
         "no-slash-here",
         pgrx::JsonB(serde_json::json!({})),
-        None,
-        None,
         None,
         None,
     );
@@ -40,9 +36,7 @@ fn test_grpc_call_reflection_disabled_misses_registry() {
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hello"})),
         None,
-        None,
-        Some(false),
-        None,
+        Some(pgrx::JsonB(serde_json::json!({"use_reflection": false}))),
     );
 }
 
@@ -66,9 +60,7 @@ fn test_grpc_call_reflection_disabled_hits_registry() {
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "no-reflection"})),
         None,
-        None,
-        Some(false),
-        None,
+        Some(pgrx::JsonB(serde_json::json!({"use_reflection": false}))),
     );
     assert_eq!(result.0["f_string"], "no-reflection");
 
@@ -95,8 +87,6 @@ fn test_grpc_call_method_not_found() {
         pgrx::JsonB(serde_json::json!({"f_string": "x"})),
         None,
         None,
-        None,
-        None,
     );
 }
 
@@ -111,8 +101,6 @@ fn test_grpc_call_with_metadata_smoke() {
             "authorization": "Bearer tok",
             "x-trace-id": "abc"
         }))),
-        None,
-        None,
         None,
     );
     assert_eq!(result.0["f_string"], "hello");
@@ -252,35 +240,29 @@ fn test_grpc_call_timeout_fires() {
         "x.Y/Z",
         pgrx::JsonB(serde_json::json!({})),
         None,
-        Some(200),
-        None,
-        None,
+        Some(pgrx::JsonB(serde_json::json!({"timeout_ms": 200}))),
     );
 }
 
-#[pg_test(error = "timeout_ms must be positive (got 0)")]
+#[pg_test(error = "Connection error: options.timeout_ms must be >= 1 (got 0)")]
 fn test_grpc_call_timeout_zero_rejected() {
     crate::grpc_call(
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hi"})),
         None,
-        Some(0),
-        None,
-        None,
+        Some(pgrx::JsonB(serde_json::json!({"timeout_ms": 0}))),
     );
 }
 
-#[pg_test(error = "timeout_ms must be positive (got -5)")]
+#[pg_test(error = "Connection error: options.timeout_ms must be >= 1 (got -5)")]
 fn test_grpc_call_timeout_negative_rejected() {
     crate::grpc_call(
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "hi"})),
         None,
-        Some(-5),
-        None,
-        None,
+        Some(pgrx::JsonB(serde_json::json!({"timeout_ms": -5}))),
     );
 }
 

--- a/src/tests/call.rs
+++ b/src/tests/call.rs
@@ -266,6 +266,61 @@ fn test_grpc_call_timeout_negative_rejected() {
     );
 }
 
+// Encode-cap wiring: stage a proto so reflection is bypassed, then cap the
+// encode size at 1 byte. The non-empty request body must trigger tonic's
+// encode-size enforcement and surface as a Call error. Server-independent.
+#[pg_test]
+fn test_grpc_call_encode_cap_fires() {
+    crate::grpc_proto_unregister_all();
+    crate::grpc_proto_unstage_all();
+    crate::grpc_proto_stage(
+        "dummy.proto",
+        r#"
+        syntax = "proto3";
+        package grpcbin;
+        service GRPCBin { rpc DummyUnary(DummyMessage) returns (DummyMessage); }
+        message DummyMessage { string f_string = 1; }
+        "#,
+    );
+    crate::grpc_proto_compile();
+
+    let result = std::panic::catch_unwind(|| {
+        crate::grpc_call(
+            &grpcbin_endpoint(),
+            "grpcbin.GRPCBin/DummyUnary",
+            pgrx::JsonB(serde_json::json!({"f_string": "this-will-not-fit"})),
+            None,
+            Some(pgrx::JsonB(serde_json::json!({
+                "use_reflection": false,
+                "max_encode_message_size_bytes": 1
+            }))),
+        )
+    });
+    crate::grpc_proto_unregister_all();
+    assert!(
+        result.is_err(),
+        "expected encode-size cap to abort the call"
+    );
+}
+
+// Decode-cap happy path: setting a generous decode limit must not break a
+// normal small call. Proves the decode knob flows through to tonic without
+// breaking the common path.
+#[pg_test]
+fn test_grpc_call_large_decode_limit_does_not_break_happy_path() {
+    crate::grpc_proto_unregister_all();
+    let result = crate::grpc_call(
+        &grpcbin_endpoint(),
+        "grpcbin.GRPCBin/DummyUnary",
+        pgrx::JsonB(serde_json::json!({"f_string": "decode-knob"})),
+        None,
+        Some(pgrx::JsonB(serde_json::json!({
+            "max_decode_message_size_bytes": 67_108_864
+        }))),
+    );
+    assert_eq!(result.0["f_string"], "decode-knob");
+}
+
 #[pg_test]
 fn test_parse_method_accepts_valid() {
     let (service, method) = crate::call::parse_method("pkg.Service/Method").unwrap();

--- a/src/tests/endpoint.rs
+++ b/src/tests/endpoint.rs
@@ -72,8 +72,6 @@ fn test_grpc_call_rejects_http_prefixed_endpoint() {
         pgrx::JsonB(serde_json::json!({})),
         None,
         None,
-        None,
-        None,
     );
 }
 
@@ -83,8 +81,6 @@ fn test_grpc_call_rejects_empty_endpoint() {
         "",
         "pkg.Service/Method",
         pgrx::JsonB(serde_json::json!({})),
-        None,
-        None,
         None,
         None,
     );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -22,6 +22,7 @@ mod tests {
     include!("compile.rs");
     include!("endpoint.rs");
     include!("list.rs");
+    include!("options.rs");
     include!("registry.rs");
     include!("staging.rs");
     include!("tls.rs");

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -120,3 +120,103 @@ fn test_options_parse_tls_inner_error_surfaces() {
     assert!(msg.contains("tls"), "{msg}");
     assert!(msg.contains("unknown key"), "{msg}");
 }
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_propagates() {
+    let cfg = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": 67_108_864}),
+    )
+    .unwrap();
+    assert_eq!(cfg.max_decode_message_size_bytes, Some(67_108_864));
+}
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_zero_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": 0}),
+    )
+    .expect_err("zero must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_decode_message_size_bytes"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_negative_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": -1}),
+    )
+    .expect_err("negative must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_decode_message_size_bytes"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_above_u32_max_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": 4_294_967_296i64}),
+    )
+    .expect_err("above u32::MAX must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_decode_message_size_bytes"), "{msg}");
+    assert!(msg.contains("4294967295"), "must mention wire limit: {msg}");
+}
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_at_u32_max_accepted() {
+    let cfg = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": 4_294_967_295u32}),
+    )
+    .unwrap();
+    assert_eq!(cfg.max_decode_message_size_bytes, Some(u32::MAX));
+}
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_string_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": "64MB"}),
+    )
+    .expect_err("string must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_decode_message_size_bytes"), "{msg}");
+    assert!(msg.contains("integer"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_max_decode_message_size_bytes_float_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_decode_message_size_bytes": 1.5}),
+    )
+    .expect_err("float must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_decode_message_size_bytes"), "{msg}");
+    assert!(msg.contains("integer"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_max_encode_message_size_bytes_propagates() {
+    let cfg = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_encode_message_size_bytes": 4_194_304}),
+    )
+    .unwrap();
+    assert_eq!(cfg.max_encode_message_size_bytes, Some(4_194_304));
+}
+
+#[pg_test]
+fn test_options_parse_max_encode_message_size_bytes_negative_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_encode_message_size_bytes": -1}),
+    )
+    .expect_err("negative must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_encode_message_size_bytes"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_max_encode_message_size_bytes_above_u32_max_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"max_encode_message_size_bytes": 4_294_967_296i64}),
+    )
+    .expect_err("above u32::MAX must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.max_encode_message_size_bytes"), "{msg}");
+}

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -60,3 +60,63 @@ fn test_options_parse_timeout_ms_float_rejected() {
     assert!(msg.contains("options.timeout_ms"), "{msg}");
     assert!(msg.contains("integer"), "{msg}");
 }
+
+#[pg_test]
+fn test_options_parse_use_reflection_propagates() {
+    let cfg =
+        crate::options::OptionsConfig::parse(&serde_json::json!({"use_reflection": true}))
+            .unwrap();
+    assert_eq!(cfg.use_reflection, Some(true));
+    let cfg =
+        crate::options::OptionsConfig::parse(&serde_json::json!({"use_reflection": false}))
+            .unwrap();
+    assert_eq!(cfg.use_reflection, Some(false));
+}
+
+#[pg_test]
+fn test_options_parse_use_reflection_string_rejected() {
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"use_reflection": "yes"}),
+    )
+    .expect_err("string must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.use_reflection"), "{msg}");
+    assert!(msg.contains("boolean"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_tls_propagates() {
+    let cfg =
+        crate::options::OptionsConfig::parse(&serde_json::json!({"tls": {"ca_cert": "PEM"}}))
+            .unwrap();
+    let tls = cfg.tls.expect("tls config must be set");
+    assert_eq!(tls.ca_cert.as_deref(), Some("PEM".as_bytes()));
+}
+
+#[pg_test]
+fn test_options_parse_tls_null_treated_as_absent() {
+    let cfg = crate::options::OptionsConfig::parse(&serde_json::json!({"tls": null})).unwrap();
+    assert!(cfg.tls.is_none());
+}
+
+#[pg_test]
+fn test_options_parse_tls_array_rejected() {
+    let err = crate::options::OptionsConfig::parse(&serde_json::json!({"tls": [1, 2]}))
+        .expect_err("array must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.tls"), "{msg}");
+    assert!(msg.contains("object"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_tls_inner_error_surfaces() {
+    // Inner TlsConfig::parse rejects unknown keys; the outer parser must let
+    // that error through so users see a tls-prefixed diagnostic.
+    let err = crate::options::OptionsConfig::parse(
+        &serde_json::json!({"tls": {"not_a_field": "x"}}),
+    )
+    .expect_err("inner tls error must surface");
+    let msg = err.to_string();
+    assert!(msg.contains("tls"), "{msg}");
+    assert!(msg.contains("unknown key"), "{msg}");
+}

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -1,0 +1,19 @@
+#[pg_test]
+fn test_options_parse_null_yields_all_none() {
+    let cfg = crate::options::OptionsConfig::parse(&serde_json::Value::Null).unwrap();
+    assert!(cfg.timeout_ms.is_none());
+    assert!(cfg.use_reflection.is_none());
+    assert!(cfg.tls.is_none());
+    assert!(cfg.max_decode_message_size_bytes.is_none());
+    assert!(cfg.max_encode_message_size_bytes.is_none());
+}
+
+#[pg_test]
+fn test_options_parse_empty_object_yields_all_none() {
+    let cfg = crate::options::OptionsConfig::parse(&serde_json::json!({})).unwrap();
+    assert!(cfg.timeout_ms.is_none());
+    assert!(cfg.use_reflection.is_none());
+    assert!(cfg.tls.is_none());
+    assert!(cfg.max_decode_message_size_bytes.is_none());
+    assert!(cfg.max_encode_message_size_bytes.is_none());
+}

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -17,3 +17,46 @@ fn test_options_parse_empty_object_yields_all_none() {
     assert!(cfg.max_decode_message_size_bytes.is_none());
     assert!(cfg.max_encode_message_size_bytes.is_none());
 }
+
+#[pg_test]
+fn test_options_parse_timeout_ms_propagates() {
+    let cfg = crate::options::OptionsConfig::parse(&serde_json::json!({"timeout_ms": 5000}))
+        .unwrap();
+    assert_eq!(cfg.timeout_ms, Some(5000));
+}
+
+#[pg_test]
+fn test_options_parse_timeout_ms_zero_rejected() {
+    let err = crate::options::OptionsConfig::parse(&serde_json::json!({"timeout_ms": 0}))
+        .expect_err("zero must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.timeout_ms"), "{msg}");
+    assert!(msg.contains(">= 1"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_timeout_ms_negative_rejected() {
+    let err = crate::options::OptionsConfig::parse(&serde_json::json!({"timeout_ms": -1}))
+        .expect_err("negative must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.timeout_ms"), "{msg}");
+    assert!(msg.contains(">= 1"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_timeout_ms_string_rejected() {
+    let err = crate::options::OptionsConfig::parse(&serde_json::json!({"timeout_ms": "fast"}))
+        .expect_err("string must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.timeout_ms"), "{msg}");
+    assert!(msg.contains("integer"), "{msg}");
+}
+
+#[pg_test]
+fn test_options_parse_timeout_ms_float_rejected() {
+    let err = crate::options::OptionsConfig::parse(&serde_json::json!({"timeout_ms": 1.5}))
+        .expect_err("float must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("options.timeout_ms"), "{msg}");
+    assert!(msg.contains("integer"), "{msg}");
+}

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -220,3 +220,56 @@ fn test_options_parse_max_encode_message_size_bytes_above_u32_max_rejected() {
     let msg = err.to_string();
     assert!(msg.contains("options.max_encode_message_size_bytes"), "{msg}");
 }
+
+#[pg_test]
+fn test_options_parse_unknown_key_rejected_with_accepted_keys_listed() {
+    let err = crate::options::OptionsConfig::parse(&serde_json::json!({"tiemout_ms": 5000}))
+        .expect_err("unknown key must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown"), "{msg}");
+    assert!(msg.contains("tiemout_ms"), "must echo offending key: {msg}");
+    for key in [
+        "timeout_ms",
+        "use_reflection",
+        "tls",
+        "max_decode_message_size_bytes",
+        "max_encode_message_size_bytes",
+    ] {
+        assert!(msg.contains(key), "accepted key {key} not in error: {msg}");
+    }
+}
+
+#[pg_test]
+fn test_options_parse_non_object_rejected() {
+    for non_obj in [
+        serde_json::json!("plain-string"),
+        serde_json::json!([1, 2, 3]),
+        serde_json::json!(42),
+        serde_json::json!(true),
+    ] {
+        let err = crate::options::OptionsConfig::parse(&non_obj)
+            .expect_err("non-object must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("options must be a JSON object"),
+            "unexpected: {msg}"
+        );
+    }
+}
+
+#[pg_test]
+fn test_options_parse_full_blob_propagates_every_key() {
+    let cfg = crate::options::OptionsConfig::parse(&serde_json::json!({
+        "timeout_ms": 5000,
+        "use_reflection": false,
+        "tls": {"ca_cert": "PEM"},
+        "max_decode_message_size_bytes": 67_108_864,
+        "max_encode_message_size_bytes": 4_194_304,
+    }))
+    .unwrap();
+    assert_eq!(cfg.timeout_ms, Some(5000));
+    assert_eq!(cfg.use_reflection, Some(false));
+    assert!(cfg.tls.is_some());
+    assert_eq!(cfg.max_decode_message_size_bytes, Some(67_108_864));
+    assert_eq!(cfg.max_encode_message_size_bytes, Some(4_194_304));
+}

--- a/src/tests/registry.rs
+++ b/src/tests/registry.rs
@@ -52,8 +52,6 @@ fn test_registry_precedence_over_reflection() {
         pgrx::JsonB(serde_json::json!({"renamed_field": "winner"})),
         None,
         None,
-        None,
-        None,
     );
     assert_eq!(result.0["renamed_field"], "winner");
     assert!(

--- a/src/tests/staging.rs
+++ b/src/tests/staging.rs
@@ -21,8 +21,6 @@ fn test_grpc_proto_stage_single_file() {
         pgrx::JsonB(serde_json::json!({"f_string": "via-registry"})),
         None,
         None,
-        None,
-        None,
     );
     assert_eq!(result.0["f_string"], "via-registry");
 }
@@ -54,8 +52,6 @@ fn test_grpc_proto_stage_cross_import() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "multi-file"})),
-        None,
-        None,
         None,
         None,
     );
@@ -94,8 +90,6 @@ fn test_grpc_proto_unstage_recovers_bad_file() {
         &grpcbin_endpoint(),
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "recovered"})),
-        None,
-        None,
         None,
         None,
     );

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -229,9 +229,7 @@ fn test_grpc_call_tls_reflection_e2e() {
         "grpcbin.GRPCBin/DummyUnary",
         pgrx::JsonB(serde_json::json!({"f_string": "tls-hello"})),
         None,
-        None,
-        None,
-        Some(pgrx::JsonB(serde_json::json!({}))),
+        Some(pgrx::JsonB(serde_json::json!({"tls": {}}))),
     );
     assert_eq!(result.0["f_string"], "tls-hello");
     crate::grpc_proto_unregister_all();


### PR DESCRIPTION
Closes #26.

## Summary

- **BREAKING CHANGE:** collapses `timeout_ms`, `use_reflection` and `tls` from positional `grpc_call` arguments into a single strict-parsed `options jsonb` blob.
- Adds `max_decode_message_size_bytes` and `max_encode_message_size_bytes` per-call knobs so users can raise tonic's 4 MiB decode cap

## Migration

| Before                                                 | After                                                                       |
| ------------------------------------------------------ | --------------------------------------------------------------------------- |
| `grpc_call(..., timeout_ms => 5000)`                   | `grpc_call(..., options => '{"timeout_ms": 5000}')`                         |
| `grpc_call(..., use_reflection => false)`              | `grpc_call(..., options => '{"use_reflection": false}')`                    |
| `grpc_call(..., tls => '{}'::jsonb)`                   | `grpc_call(..., options => '{"tls": {}}')`                                  |
| `grpc_call(..., tls => '{"ca_cert": "<PEM>"}'::jsonb)` | `grpc_call(..., options => '{"tls": {"ca_cert": "<PEM>"}}')`                |
| _(no way to raise 4 MB decode cap)_                    | `grpc_call(..., options => '{"max_decode_message_size_bytes": 67108864}')`  |
