### PR TITLE
Fix: any wkt resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,8 @@ grpc_proto_compile()
 
 The `InMemoryResolver` in `proto.rs` implements `protox::file::FileResolver` — it serves staged files by filename. It's chained with `GoogleFileResolver` so imports like `google/protobuf/timestamp.proto` resolve against protox's bundled WKT copies. No filesystem, no network.
 
+After compile, `backfill_wkts` seeds every pool with `prost_reflect::DescriptorPool::global()`'s bundled WKTs. This lets `Any` payloads referencing a WKT (`google.protobuf.StringValue`, `Timestamp`, `Duration`, …) resolve at encode time even when the user proto only imports `any.proto`. User-staged files keep priority: same-name files added before the backfill are not overridden.
+
 ### 2. Reflection (fallback when nothing is registered)
 
 `proto::fetch_pool(channel, service_name)` calls the server's `grpc.reflection.v1alpha.ServerReflection` service with a `FileContainingSymbol` request, decodes the streamed `FileDescriptorProto`s, and builds a `DescriptorPool`. The first call for a given service populates `PROTO_REGISTRY` with `Origin::Reflection { endpoint }`; subsequent calls hit the cache. Reflection caching is per-backend-process — reconnect (or `grpc_proto_unregister`) to force a refresh.

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -130,7 +130,27 @@ pub fn compile_proto_files(files: HashMap<String, String>) -> GrpcResult<Descrip
         ));
     }
 
+    backfill_wkts(&mut pool)?;
     Ok(pool)
+}
+
+// Seed the pool with every Google Well-Known Type that prost_reflect ships
+// (Any, Duration, Timestamp, wrappers, Struct, ...). Without this, a JSON
+// `Any` payload whose `@type` URL references a WKT (e.g. StringValue) cannot
+// be resolved at encode time unless the user happened to import the
+// containing proto. User-supplied or server-returned files added before this
+// call always win — same-name files are skipped, never overridden.
+pub fn backfill_wkts(pool: &mut DescriptorPool) -> GrpcResult<()> {
+    let global = DescriptorPool::global();
+    for file in global.files() {
+        let name = file.name().to_owned();
+        if pool.get_file_by_name(&name).is_some() {
+            continue;
+        }
+        pool.add_file_descriptor_proto(file.file_descriptor_proto().clone())
+            .map_err(|e| GrpcError::ProtoCompile(format!("seed WKT {name}: {e}")))?;
+    }
+    Ok(())
 }
 
 struct InMemoryResolver {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -144,6 +144,9 @@ pub fn backfill_wkts(pool: &mut DescriptorPool) -> GrpcResult<()> {
     let global = DescriptorPool::global();
     for file in global.files() {
         let name = file.name().to_owned();
+        // prost_reflect's add_file_descriptor_proto dedupes by filename
+        // already; the explicit guard here makes the user-staged-wins
+        // policy visible to readers and avoids relying on that dedup.
         if pool.get_file_by_name(&name).is_some() {
             continue;
         }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -16,14 +16,17 @@ pub async fn fetch_pool(
 ) -> GrpcResult<DescriptorPool> {
     // Prefer the stable v1 service (grpc.reflection.v1.ServerReflection).
     // Fall back to v1alpha if the server hasn't implemented v1 yet.
-    match fetch_v1(channel.clone(), service_name, max_decode, max_encode).await {
+    let mut pool = match fetch_v1(channel.clone(), service_name, max_decode, max_encode).await {
         Ok(pool) => Ok(pool),
         Err(s) if s.code() == tonic::Code::Unimplemented => {
             fetch_v1alpha(channel, service_name, max_decode, max_encode).await
         }
         Err(s) => Err(s),
     }
-    .map_err(|s| GrpcError::Proto(format!("reflection: {}", s.message())))
+    .map_err(|s| GrpcError::Proto(format!("reflection: {}", s.message())))?;
+
+    backfill_wkts(&mut pool)?;
+    Ok(pool)
 }
 
 macro_rules! define_fetch {
@@ -134,19 +137,10 @@ pub fn compile_proto_files(files: HashMap<String, String>) -> GrpcResult<Descrip
     Ok(pool)
 }
 
-// Seed the pool with every Google Well-Known Type that prost_reflect ships
-// (Any, Duration, Timestamp, wrappers, Struct, ...). Without this, a JSON
-// `Any` payload whose `@type` URL references a WKT (e.g. StringValue) cannot
-// be resolved at encode time unless the user happened to import the
-// containing proto. User-supplied or server-returned files added before this
-// call always win — same-name files are skipped, never overridden.
 pub fn backfill_wkts(pool: &mut DescriptorPool) -> GrpcResult<()> {
     let global = DescriptorPool::global();
     for file in global.files() {
         let name = file.name().to_owned();
-        // prost_reflect's add_file_descriptor_proto dedupes by filename
-        // already; the explicit guard here makes the user-staged-wins
-        // policy visible to readers and avoids relying on that dedup.
         if pool.get_file_by_name(&name).is_some() {
             continue;
         }

--- a/src/tests/compile.rs
+++ b/src/tests/compile.rs
@@ -81,3 +81,35 @@ fn test_compile_google_wkt_import() {
         "service test_wkt.Event should be in the compiled pool"
     );
 }
+
+// Regression for #31: encoding a JSON Any payload whose @type points at a WKT
+// (StringValue, lives in google/protobuf/wrappers.proto) must succeed even
+// though the user proto only imports google/protobuf/any.proto. Without the
+// WKT auto-seed in compile_proto_files, MessageDescriptor::deserialize errors
+// with "message 'google.protobuf.StringValue' not found".
+#[pg_test]
+fn wkt_any_payload_encodes() {
+    use prost_reflect::DynamicMessage;
+    use serde::de::DeserializeSeed as _;
+
+    let files = one_file(
+        "any_test.proto",
+        r#"
+        syntax = "proto3";
+        import "google/protobuf/any.proto";
+        package wkt_any_test;
+        service S { rpc M(Msg) returns (Msg); }
+        message Msg { google.protobuf.Any payload = 1; }
+        "#,
+    );
+    let pool = crate::proto::compile_proto_files(files).expect("compile must succeed");
+
+    let desc = pool
+        .get_message_by_name("wkt_any_test.Msg")
+        .expect("wkt_any_test.Msg should be in pool");
+    let json = r#"{"payload":{"@type":"type.googleapis.com/google.protobuf.StringValue","value":"hi"}}"#;
+    let mut de = serde_json::Deserializer::from_str(json);
+    let _msg: DynamicMessage = desc
+        .deserialize(&mut de)
+        .expect("Any payload referencing WKT should deserialize against compiled pool");
+}

--- a/src/tests/compile.rs
+++ b/src/tests/compile.rs
@@ -82,6 +82,45 @@ fn test_compile_google_wkt_import() {
     );
 }
 
+// User staging a file at a WKT filename must win: the user's StringValue
+// declares a custom field, and after compile the pool must hold *that*
+// version, not the bundled wrappers.proto's StringValue.
+#[pg_test]
+fn user_staged_wkt_name_does_not_conflict() {
+    let mut files = HashMap::new();
+    files.insert(
+        "google/protobuf/wrappers.proto".to_string(),
+        r#"
+        syntax = "proto3";
+        package google.protobuf;
+        message StringValue { string custom_value = 1; }
+        "#
+        .to_string(),
+    );
+    files.insert(
+        "service.proto".to_string(),
+        r#"
+        syntax = "proto3";
+        import "google/protobuf/wrappers.proto";
+        package custom_wkt_test;
+        service S { rpc M(Msg) returns (Msg); }
+        message Msg { google.protobuf.StringValue v = 1; }
+        "#
+        .to_string(),
+    );
+
+    let pool = crate::proto::compile_proto_files(files)
+        .expect("user wrappers.proto override should compile cleanly");
+
+    let sv = pool
+        .get_message_by_name("google.protobuf.StringValue")
+        .expect("user-staged StringValue should be present");
+    assert!(
+        sv.get_field_by_name("custom_value").is_some(),
+        "pool must hold the user's StringValue (custom_value field), not the bundled one"
+    );
+}
+
 // Regression for #31: encoding a JSON Any payload whose @type points at a WKT
 // (StringValue, lives in google/protobuf/wrappers.proto) must succeed even
 // though the user proto only imports google/protobuf/any.proto. Without the


### PR DESCRIPTION
## Summary

- `Any` payloads whose `@type` URL points at a WKT (e.g. `google.protobuf.StringValue`) failed to encode unless the user proto transitively imported the WKT's file. Same gap on the reflection path.
- New `proto::backfill_wkts` seeds every pool with `prost_reflect::DescriptorPool::global()`'s bundled WKTs after user/server files are added. User-staged files keep priority on filename conflict.
- One helper, two call sites (`compile_proto_files` + `fetch_pool`). No SQL-surface change.

Closes #31
